### PR TITLE
Fix search input style

### DIFF
--- a/themes/github_theme.json
+++ b/themes/github_theme.json
@@ -413,7 +413,7 @@
         "icon.accent": "#74ade8ff",
         "status_bar.background": "#24292eff",
         "title_bar.background": "#24292eff",
-        "toolbar.background": "#1f2428ff",
+        "toolbar.background": "#24292eff",
         "tab_bar.background": "#1f2428ff",
         "tab.inactive_background": "#1f2428ff",
         "tab.active_background": "#24292eff",


### PR DESCRIPTION
Closes issue #1

Makes `"toolbar.background"` the same color as  `"editor.background"` in order to fix https://github.com/PyaeSoneAungRgn/github-zed-theme/issues/1