### PR TITLE
Update tag color to be a middle-green color

### DIFF
--- a/themes/github_theme.json
+++ b/themes/github_theme.json
@@ -340,7 +340,7 @@
             "font_weight": null
           },
           "tag": {
-            "color": "#24292eff",
+            "color": "#22863aff",
             "font_style": null,
             "font_weight": null
           },


### PR DESCRIPTION
XML tags show up in the same foreground color instead of a green shade in Github.

In Zed:
<img width="436" alt="image" src="https://github.com/user-attachments/assets/75490491-4b6e-4cb9-a33d-677ffe64a767">

VSCode Github Light Theme:
<img width="434" alt="image" src="https://github.com/user-attachments/assets/90104631-d16d-4896-848a-a8b1d8ffaa79">

Updated theme in Zed:
<img width="435" alt="image" src="https://github.com/user-attachments/assets/083dee71-751f-42fc-b8b9-40f7d233e3c0">

The color is from https://github.com/primer/github-vscode-theme/blob/main/src/classic/colors.json