### PR TITLE
Highlight type nodes the same as variable nodes

### DIFF
--- a/themes/github_theme.json
+++ b/themes/github_theme.json
@@ -355,7 +355,7 @@
             "font_weight": 400
           },
           "type": {
-            "color": "#d73a49ff",
+            "color": "#24292eff",
             "font_style": null,
             "font_weight": null
           },
@@ -729,7 +729,7 @@
             "font_weight": 400
           },
           "type": {
-            "color": "#f97583ff",
+            "color": "#e1e4e8ff",
             "font_style": null,
             "font_weight": null
           },


### PR DESCRIPTION
This is how GitHub does it, for example:

```c
static int findarg(const void *a, const void *b)
{
  const struct LongShort *aa = a;
  const struct LongShort *bb = b;
  return strcmp(aa->lname, bb->lname);
}
```

`LongShort` is the type and `aa` is the variable name, both have the same color.

In Zed, before

<img width="392" alt="Screenshot 2024-09-04 at 14 10 03" src="https://github.com/user-attachments/assets/2c418d69-80d2-4b96-b16c-b43f22cb3f16">

after

<img width="404" alt="Screenshot 2024-09-04 at 14 09 42" src="https://github.com/user-attachments/assets/bb0f72ab-a089-4de2-bbd7-b46a5dc8969e">

The `*` and `->` are still wrong though.