### PR TITLE
Generate themes from primer design system, add accessible themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -21,3 +21,17 @@ Project inspired on [GitHub's VS Code theme](https://github.com/primer/github-vs
 ## Contributing
 
 Feel free to fork, make changes, and submit a pull request.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Publishing new versions
+
+1. Update the version in `extension.toml`
+2. Run `npm run build`
+3. Commit and push your changes (make sure to push the built files in `themes/` as well)
+4. Follow the [Zed publishing docs](https://zed.dev/docs/extensions/developing-extensions#updating-an-extension) to publish the extension

--- a/extension.json
+++ b/extension.json
@@ -1,9 +1,0 @@
-{
-  "name": "GitHub Theme",
-  "version": "0.0.2",
-  "authors": [
-    "Pyae Sone Aung <pyaesoneaungrgn@gmail.com>"
-  ],
-  "description": "GitHub theme for Zed",
-  "repository": "https://github.com/PyaeSoneAungRgn/github-zed-theme"
-}

--- a/extension.toml
+++ b/extension.toml
@@ -1,0 +1,7 @@
+id = "github-theme"
+name = "Github Theme"
+version = "0.0.3"
+schema_version = 1
+authors = ["Pyae Sone Aung <pyaesoneaungrgn@gmail.com>", "Clay Tercek"]
+description = "GitHub themes for Zed"
+repository = "https://github.com/PyaeSoneAungRgn/github-zed-theme"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "github-zed-theme-generator",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node --watch src/generate",
+    "build": "node src/generate"
+  },
+  "devDependencies": {
+    "@primer/primitives": "^9.1.1",
+    "@types/node": "^20.14.6",
+    "typescript": "^5.4.5"
+  }
+}

--- a/src/generate.js
+++ b/src/generate.js
@@ -6,11 +6,11 @@ const writeData = {
   "name": "Github Theme",
   "author": "Pyae Sone Aung",
   "themes": [
-    getTheme({ themeKey: 'light', name: "Github Light Default", type: 'light' }),
+    getTheme({ themeKey: 'light', name: "Github Light", type: 'light' }),
     getTheme({ themeKey: 'light_colorblind', name: "Github Light Colorblind", type: 'light' }),
     getTheme({ themeKey: 'light_high_contrast', name: "Github Light High Contrast", type: 'light' }),
     getTheme({ themeKey: 'light_tritanopia', name: "Github Light Tritanopia", type: 'light' }),
-    getTheme({ themeKey: 'dark', name: "Github Dark Default", type: 'dark' }),
+    getTheme({ themeKey: 'dark', name: "Github Dark", type: 'dark' }),
     getTheme({ themeKey: 'dark_colorblind', name: "Github Dark Colorblind", type: 'dark' }),
     getTheme({ themeKey: 'dark_high_contrast', name: "Github Dark High Contrast", type: 'dark' }),
     getTheme({ themeKey: 'dark_tritanopia', name: "Github Dark Tritanopia", type: 'dark' }),

--- a/src/generate.js
+++ b/src/generate.js
@@ -1,0 +1,23 @@
+import fs from 'node:fs/promises'
+import { getTheme } from './theme.js'
+
+const writeData = {
+  "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+  "name": "Github Theme",
+  "author": "Pyae Sone Aung",
+  "themes": [
+    getTheme({ themeKey: 'light', name: "Github Light Default", type: 'light' }),
+    getTheme({ themeKey: 'light_colorblind', name: "Github Light Colorblind", type: 'light' }),
+    getTheme({ themeKey: 'light_high_contrast', name: "Github Light High Contrast", type: 'light' }),
+    getTheme({ themeKey: 'light_tritanopia', name: "Github Light Tritanopia", type: 'light' }),
+    getTheme({ themeKey: 'dark', name: "Github Dark Default", type: 'dark' }),
+    getTheme({ themeKey: 'dark_colorblind', name: "Github Dark Colorblind", type: 'dark' }),
+    getTheme({ themeKey: 'dark_high_contrast', name: "Github Dark High Contrast", type: 'dark' }),
+    getTheme({ themeKey: 'dark_tritanopia', name: "Github Dark Tritanopia", type: 'dark' }),
+    getTheme({ themeKey: 'dark_dimmed', name: "Github Dark Dimmed", type: 'dark' }),
+  ]
+}
+
+await fs.mkdir('./themes', { recursive: true })
+
+await fs.writeFile('./themes/github_theme.json', JSON.stringify(writeData, null, 2))

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,23 @@
+
+type Token = {
+  name: string
+} & (
+    | { type: 'COLOR'; value: { r: number; g: number; b: number; a: number } }
+    | { type: 'FLOAT'; value: number }
+  );
+
+declare module '@primer/primitives/dist/figma/themes/*.json' {
+  type Theme = Token[];
+
+  const theme: Theme;
+
+  export default theme;
+}
+
+declare module '@primer/primitives/dist/figma/scales/*.json' {
+  type Scale = Token[];
+
+  const scale: Scale;
+
+  export default scale;
+}

--- a/src/theme.js
+++ b/src/theme.js
@@ -226,7 +226,7 @@ export function getTheme({ themeKey, name, type }) {
           "font_weight": null
         },
         "constructor": {
-          "color": lightDark("base/color/orange/6", "base/color/orange/2"),
+          "color": lightDark("base/color/blue/6", "base/color/blue/2"),
           "font_style": null,
           "font_weight": null
         },

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,411 @@
+import { getColorTokens } from "./tokens.js";
+
+
+/**
+ * @param {object} params
+ * @param {import("./tokens.js").ThemeKey} params.themeKey
+ * @param {string} params.name
+ * @param {'light' | 'dark'} params.type
+ */
+export function getTheme({ themeKey, name, type }) {
+  const tokens = getColorTokens(themeKey)
+
+  /**
+   * @param {string} lightTokenName
+   * @param {string} darkTokenName
+   */
+  const lightDark = (lightTokenName, darkTokenName) => {
+    return themeKey.startsWith('light') ? tokens[lightTokenName] : tokens[darkTokenName]
+  }
+
+  return {
+    "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+    appearance: type,
+    name,
+    style: {
+      "background": tokens['bgColor/default'],
+      "border": tokens['borderColor/default'],
+
+      "border.disabled": tokens['borderColor/disabled'],
+      "border.focused": tokens['borderColor/accent-emphasis'],
+      "border.selected": tokens['borderColor/accent-emphasis'],
+      "border.transparent": tokens['borderColor/transparent'],
+      "border.variant": tokens['borderColor/muted'],
+
+      "conflict": tokens['fgColor/severe'],
+      "conflict.background": tokens['bgColor/severe-muted'],
+      "conflict.border": tokens['borderColor/severe-muted'],
+
+      "created": tokens['fgColor/success'],
+      "created.background": tokens['bgColor/success-muted'],
+      "created.border": tokens['borderColor/success-muted'],
+
+      "deleted": tokens['fgColor/danger'],
+      "deleted.background": tokens['bgColor/danger-muted'],
+      "deleted.border": tokens['borderColor/danger-muted'],
+
+      "drop_target.background": tokens['bgColor/accent-muted'],
+
+      "editor.active_line.background": tokens['bgColor/muted'],
+      "editor.active_line_number": tokens['fgColor/default'],
+      "editor.active_wrap_guide": tokens['borderColor/muted'],
+      "editor.background": tokens['bgColor/default'],
+      "editor.document_highlight.read_background": tokens['bgColor/accent-muted'],
+      "editor.document_highlight.write_background": tokens['bgColor/accent-emphasis'],
+      "editor.foreground": tokens['fgColor/default'],
+      "editor.gutter.background": tokens['bgColor/default'],
+      "editor.highlighted_line.background": tokens['bgColor/neutral-muted'],
+      "editor.invisible": tokens['fgColor/disabled'],
+      "editor.line_number": tokens['fgColor/muted'],
+      "editor.subheader.background": tokens['bgColor/muted'],
+      "editor.wrap_guide": tokens['borderColor/muted'],
+
+      "element.active": tokens['bgColor/neutral-muted'],
+      "element.background": tokens['bgColor/neutral-muted'],
+      "element.disabled": tokens['bgColor/disabled'],
+      "element.hover": tokens['bgColor/neutral-muted'],
+      "element.selected": tokens['bgColor/neutral-muted'],
+
+      "elevated_surface.background": tokens['bgColor/muted'],
+
+      "error": tokens['fgColor/danger'],
+      "error.background": tokens['bgColor/muted'],
+      "error.border": tokens['borderColor/muted'],
+
+      "ghost_element.active": tokens['bgColor/neutral-muted'],
+      "ghost_element.background": tokens['bgColor/transparent'],
+      "ghost_element.disabled": tokens['bgColor/disabled'],
+      "ghost_element.hover": tokens['bgColor/default'],
+      "ghost_element.selected": tokens['bgColor/neutral-muted'],
+
+      "hint": tokens['fgColor/muted'],
+      "hint.background": tokens['bgColor/muted'],
+      "hint.border": tokens['borderColor/muted'],
+
+      "icon": tokens['fgColor/default'],
+      "icon.background": tokens['bgColor/default'],
+      "icon.border": tokens['borderColor/default'],
+      "icon.accent": tokens['fgColor/accent'],
+      "icon.muted": tokens['fgColor/muted'],
+      "icon.disabled": tokens['fgColor/disabled'],
+      "icon.placeholder": tokens['fgColor/fgColor/placeholder'],
+
+      "ignored": tokens['fgColor/disabled'],
+      "ignored.background": tokens['bgColor/disabled'],
+      "ignored.border": tokens['borderColor/disabled'],
+
+      "info": tokens['fgColor/attention'],
+      "info.background": tokens['bgColor/muted'],
+      "info.border": tokens['borderColor/muted'],
+
+      "link_text.hover": tokens['fgColor/link'],
+
+      "modified": tokens['fgColor/attention'],
+      "modified.background": tokens['bgColor/attention-muted'],
+      "modified.border": tokens['borderColor/attention-muted'],
+
+      "pane.focused_border": tokens['borderColor/default'],
+      "panel.background": tokens['bgColor/inset'],
+      "panel.focused_border": tokens['borderColor/default'],
+
+      "predictive": tokens['fgColor/placeholder'],
+      "predictive.background": tokens['bgColor/neutral-muted'],
+      "predictive.border": tokens['borderColor/neutral-muted'],
+
+      "renamed": tokens['fgColor/success'],
+      "renamed.background": tokens['bgColor/success-muted'],
+      "renamed.border": tokens['borderColor/success-muted'],
+
+      "scrollbar.thumb.border": tokens['borderColor/transparent'],
+      "scrollbar.thumb.hover_background": tokens['bgColor/muted'],
+      "scrollbar.track.background": tokens['bgColor/transparent'],
+      "scrollbar.track.border": tokens['borderColor/transparent'],
+      "scrollbar_thumb.background": tokens['bgColor/neutal-muted'],
+
+      "search.match_background": tokens['bgColor/attention-muted'],
+
+      "status_bar.background": tokens['bgColor/inset'],
+
+      "success": tokens['fgColor/success'],
+      "success.background": tokens['bgColor/success-muted'],
+      "success.border": tokens['borderColor/success-muted'],
+
+      "surface.background": tokens['bgColor/inset'],
+
+      "tab.active_background": tokens['bgColor/default'],
+      "tab.inactive_background": tokens['bgColor/inset'],
+      "tab_bar.background": tokens['bgColor/inset'],
+
+      "terminal.ansi.black": tokens['color/ansi/black'],
+      "terminal.ansi.bright_black": tokens['color/ansi/black-bright'],
+      "terminal.ansi.dim_black": tokens['color/ansi/black'],
+      "terminal.ansi.blue": tokens['color/ansi/blue'],
+      "terminal.ansi.bright_blue": tokens['color/ansi/blue-bright'],
+      "terminal.ansi.dim_blue": tokens['color/ansi/blue'],
+      "terminal.ansi.cyan": tokens['color/ansi/cyan'],
+      "terminal.ansi.bright_cyan": tokens['color/ansi/cyan-bright'],
+      "terminal.ansi.dim_cyan": tokens['color/ansi/cyan'],
+      "terminal.ansi.green": tokens['color/ansi/green'],
+      "terminal.ansi.bright_green": tokens['color/ansi/green-bright'],
+      "terminal.ansi.dim_green": tokens['color/ansi/green'],
+      "terminal.ansi.magenta": tokens['color/ansi/magenta'],
+      "terminal.ansi.bright_magenta": tokens['color/ansi/magenta-bright'],
+      "terminal.ansi.dim_magenta": tokens['color/ansi/magenta'],
+      "terminal.ansi.red": tokens['color/ansi/red'],
+      "terminal.ansi.bright_red": tokens['color/ansi/red-bright'],
+      "terminal.ansi.dim_red": tokens['color/ansi/red'],
+      "terminal.ansi.white": tokens['color/ansi/white'],
+      "terminal.ansi.bright_white": tokens['color/ansi/white-bright'],
+      "terminal.ansi.dim_white": tokens['color/ansi/white'],
+      "terminal.ansi.yellow": tokens['color/ansi/yellow'],
+      "terminal.ansi.bright_yellow": tokens['color/ansi/yellow-bright'],
+      "terminal.ansi.dim_yellow": tokens['color/ansi/yellow'],
+
+      "terminal.background": tokens['bgColor/inset'],
+      "terminal.bright_foreground": tokens['fgColor/onEmphasis'],
+      "terminal.dim_foreground": tokens['fgColor/default'],
+      "terminal.foreground": tokens['fgColor/muted'],
+
+      "text": tokens['fgColor/default'],
+      "text.accent": tokens['fgColor/accent'],
+      "text.disabled": tokens['fgColor/disabled'],
+      "text.muted": tokens['fgColor/muted'],
+      "text.placeholder": tokens['fgColor/placeholder'],
+
+      "title_bar.background": tokens['bgColor/inset'],
+      "toolbar.background": tokens['bgColor/default'],
+
+      "unreachable": tokens['fgColor/disabled'],
+      "unreachable.background": tokens['bgColor/disabled'],
+      "unreachable.border": tokens['borderColor/disabled'],
+
+      "warning": tokens['fgColor/attention'],
+      "warning.background": tokens['bgColor/muted'],
+      "warning.border": tokens['borderColor/muted'],
+
+      "players":
+        [
+          "blue",
+          "orange",
+          "pink",
+          "green",
+          "purple",
+          "yellow",
+          "teal",
+          "red"
+        ].map(color => ({
+          "cursor": tokens[`data/${color}/color`],
+          "background": tokens[`data/${color}/color/muted`],
+          "border": tokens[`data/${color}/color/muted`]
+        })),
+
+      "syntax": {
+        "attribute": {
+          "color": null,
+          "font_style": null,
+          "font_weight": null
+        },
+        "boolean": {
+          "color": lightDark("base/color/blue/6", "base/color/blue/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "comment": {
+          "color": tokens["base/color/neutral/9"],
+          "font_style": null,
+          "font_weight": null
+        },
+        "comment.doc": {
+          "color": tokens["base/color/neutral/9"],
+          "font_style": null,
+          "font_weight": null
+        },
+        "constant": {
+          "color": lightDark("base/color/blue/6", "base/color/blue/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "constructor": {
+          "color": lightDark("base/color/orange/6", "base/color/orange/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "embedded": {
+          "color": lightDark("base/color/red/5", "base/color/red/3"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "emphasis": {
+          "color": null,
+          "font_style": "italic",
+          "font_weight": null
+        },
+        "emphasis.strong": {
+          "color": null,
+          "font_style": null,
+          "font_weight": 700
+        },
+        "enum": {
+          "color": lightDark("base/color/orange/6", "base/color/orange/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "function": {
+          "color": lightDark("base/color/purple/5", "base/color/purple/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "function.method": {
+          "color": lightDark("base/color/purple/5", "base/color/purple/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "function.special.definition": {
+          "color": lightDark("base/color/purple/5", "base/color/purple/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "hint": {
+          "color": "fgColor/muted",
+          "font_style": null,
+          "font_weight": 700
+        },
+        "keyword": {
+          "color": lightDark("base/color/red/5", "base/color/red/3"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "label": {
+          "color": lightDark("base/color/blue/6", "base/color/blue/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "link_text": {
+          "color": lightDark("base/color/blue/8", "base/color/blue/1"),
+          "font_style": "italic",
+          "font_weight": null
+        },
+        "link_uri": {
+          "color": lightDark("base/color/blue/6", "base/color/blue/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "number": {
+          "color": lightDark("base/color/blue/6", "base/color/blue/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "operator": {
+          "color": "fgColor/default",
+          "font_style": null,
+          "font_weight": null
+        },
+        "predictive": {
+          "color": "fgColor/placeholder",
+          "font_style": "italic",
+          "font_weight": null
+        },
+        "preproc": {
+          "color": lightDark("base/color/red/5", "base/color/red/3"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "primary": {
+          "color": "fgColor/default",
+          "font_style": null,
+          "font_weight": null
+        },
+        "property": {
+          "color": lightDark("base/color/blue/6", "base/color/blue/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "punctuation": {
+          "color": "fgColor/default",
+          "font_style": null,
+          "font_weight": null
+        },
+        "punctuation.bracket": {
+          "color": "fgColor/default",
+          "font_style": null,
+          "font_weight": null
+        },
+        "punctuation.delimiter": {
+          "color": "fgColor/default",
+          "font_style": null,
+          "font_weight": null
+        },
+        "punctuation.list_marker": {
+          "color": lightDark("base/color/orange/6", "base/color/orange/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "punctuation.special": {
+          "color": lightDark("base/color/red/5", "base/color/red/3"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "string": {
+          "color": lightDark("base/color/blue/8", "base/color/blue/1"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "string.escape": {
+          "color": lightDark("base/color/green/6", "base/color/green/1"),
+          "font_style": "bold",
+          "font_weight": null
+        },
+        "string.regex": {
+          "color": lightDark("base/color/blue/8", "base/color/blue/1"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "string.special": {
+          "color": lightDark("base/color/blue/6", "base/color/blue/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "string.special.symbol": {
+          "color": lightDark("base/color/blue/6", "base/color/blue/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "tag": {
+          "color": lightDark("base/color/green/6", "base/color/green/1"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "text.literal": {
+          "color": lightDark("base/color/blue/6", "base/color/blue/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "title": {
+          "color": lightDark("base/color/blue/6", "base/color/blue/2"),
+          "font_style": null,
+          "font_weight": 700
+        },
+        "type": {
+          "color": lightDark("base/color/orange/6", "base/color/orange/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "variable": {
+          "color": lightDark("base/color/orange/6", "base/color/orange/2"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "variable.special": {
+          "color": lightDark("base/color/red/5", "base/color/red/3"),
+          "font_style": null,
+          "font_weight": null
+        },
+        "variant": {
+          "color": lightDark("base/color/orange/6", "base/color/orange/2"),
+          "font_style": null,
+          "font_weight": null
+        }
+      }
+    }
+  }
+}

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,0 +1,117 @@
+import lightColors from "@primer/primitives/dist/figma/themes/light.json" with { type: 'json' }
+import lightColorblindColors from "@primer/primitives/dist/figma/themes/light-colorblind.json" with { type: 'json' }
+import lightHighContrastColors from "@primer/primitives/dist/figma/themes/light-high-contrast.json" with { type: 'json' }
+import lightTritanopiaColors from "@primer/primitives/dist/figma/themes/light-tritanopia.json" with { type: 'json' }
+
+import darkColors from "@primer/primitives/dist/figma/themes/dark.json" with { type: 'json' }
+import darkColorblindColors from "@primer/primitives/dist/figma/themes/dark-colorblind.json" with { type: 'json' }
+import darkHighContrastColors from "@primer/primitives/dist/figma/themes/dark-high-contrast.json" with { type: 'json' }
+import darkTritanopiaColors from "@primer/primitives/dist/figma/themes/dark-tritanopia.json" with { type: 'json' }
+import darkDimmedColors from "@primer/primitives/dist/figma/themes/dark-dimmed.json" with { type: 'json' }
+
+import lightScale from "@primer/primitives/dist/figma/scales/light.json" with { type: 'json' }
+import lightHightContrastScale from "@primer/primitives/dist/figma/scales/light-high-constrast.json" with { type: 'json' }
+import darkScale from "@primer/primitives/dist/figma/scales/dark.json" with { type: 'json' }
+import darkHighContrastScale from "@primer/primitives/dist/figma/scales/dark-high-constrast.json" with { type: 'json' }
+import darkDimmedScale from "@primer/primitives/dist/figma/scales/dark-dimmed.json" with { type: 'json' }
+
+const themes = {
+  'light': lightColors,
+  'light_colorblind': lightColorblindColors,
+  'light_high_contrast': lightHighContrastColors,
+  'light_tritanopia': lightTritanopiaColors,
+  'dark': darkColors,
+  'dark_colorblind': darkColorblindColors,
+  'dark_high_contrast': darkHighContrastColors,
+  'dark_tritanopia': darkTritanopiaColors,
+  'dark_dimmed': darkDimmedColors,
+};
+
+/**
+ * @typedef {keyof typeof themes} ThemeKey
+ */
+
+const scales = {
+  'light': lightScale,
+  'light_high_contrast': lightHightContrastScale,
+  'dark': darkScale,
+  'dark_high_contrast': darkHighContrastScale,
+  'dark_dimmed': darkDimmedScale,
+
+  // TODO: figure out what to do for these...
+  // At the moment, primer doesn't have colorblind or tritanopia scales, 
+  // only functional color tokens (generated in the themes above)
+  'light_colorblind': lightScale,
+  'light_tritanopia': lightScale,
+  'dark_tritanopia': darkScale,
+  'dark_colorblind': darkScale,
+};
+
+
+/**
+ * Convert an rgba color to a hex color.
+ * @param {number} r
+ * @param {number} g
+ * @param {number} b
+ * @param {number} a
+ */
+function rgbaToHexA(r, g, b, a) {
+  return `#${Math.round(r * 255).toString(16).padStart(2, '0')}${Math.round(g * 255).toString(16).padStart(2, '0')}${Math.round(b * 255).toString(16).padStart(2, '0')}${Math.round(a * 255).toString(16).padStart(2, '0')}`;
+}
+
+/**
+ * @typedef ColorToken
+ * @property {string} name
+ * @property {"COLOR"} type
+ * @property {object} value
+ * @property {number} value.r
+ * @property {number} value.g
+ * @property {number} value.b
+ * @property {number} value.a
+ */
+
+/**
+ * @typedef FloatToken
+ * @property {string} name
+ * @property {"FLOAT"} type
+ * @property {number} value
+ */
+
+/**
+ * @typedef {ColorToken | FloatToken} Token
+ */
+
+/**
+ * Remap the theme to a format that is easier to use in the code.
+ * @param {Token[]} theme
+ */
+function remapTheme(theme) {
+  // imported themes are in the format with { type: 'json' }
+  // [
+  //   { name: "some/token", value: { r: 1, g: 1 b: 1 a: 1 } }
+  // ]
+  //
+  // we want to convert it to
+  // {
+  //  "some/token": "#rrggbbaa"
+  // }
+
+  return theme.reduce(
+    (acc, token) => {
+      if (token.type !== 'COLOR' || !token.value) return acc;
+      const { name, value } = token;
+      const color = rgbaToHexA(value.r, value.g, value.b, value.a);
+      acc[name] = color;
+      return acc;
+    },
+    /** @type Record<string, string> */({})
+  );
+}
+
+/**
+ * @param {ThemeKey} theme
+ */
+export function getColorTokens(theme) {
+  return { ...remapTheme(scales[theme]), ...remapTheme(themes[theme]) };
+}
+

--- a/themes/github_theme.json
+++ b/themes/github_theme.json
@@ -6,7 +6,7 @@
     {
       "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
       "appearance": "light",
-      "name": "Github Light Default",
+      "name": "Github Light",
       "style": {
         "background": "#ffffffff",
         "border": "#d1d9e0ff",
@@ -193,7 +193,7 @@
             "font_weight": null
           },
           "constructor": {
-            "color": "#953800ff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
@@ -565,7 +565,7 @@
             "font_weight": null
           },
           "constructor": {
-            "color": "#953800ff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
@@ -937,7 +937,7 @@
             "font_weight": null
           },
           "constructor": {
-            "color": "#702c00ff",
+            "color": "#023b95ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1309,7 +1309,7 @@
             "font_weight": null
           },
           "constructor": {
-            "color": "#953800ff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
@@ -1494,7 +1494,7 @@
     {
       "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
       "appearance": "dark",
-      "name": "Github Dark Default",
+      "name": "Github Dark",
       "style": {
         "background": "#0d1117ff",
         "border": "#3d444dff",
@@ -1681,7 +1681,7 @@
             "font_weight": null
           },
           "constructor": {
-            "color": "#ffa657ff",
+            "color": "#79c0ffff",
             "font_style": null,
             "font_weight": null
           },
@@ -2053,7 +2053,7 @@
             "font_weight": null
           },
           "constructor": {
-            "color": "#ffa657ff",
+            "color": "#79c0ffff",
             "font_style": null,
             "font_weight": null
           },
@@ -2425,7 +2425,7 @@
             "font_weight": null
           },
           "constructor": {
-            "color": "#ffb757ff",
+            "color": "#91cbffff",
             "font_style": null,
             "font_weight": null
           },
@@ -2797,7 +2797,7 @@
             "font_weight": null
           },
           "constructor": {
-            "color": "#ffa657ff",
+            "color": "#79c0ffff",
             "font_style": null,
             "font_weight": null
           },
@@ -3169,7 +3169,7 @@
             "font_weight": null
           },
           "constructor": {
-            "color": "#f69d50ff",
+            "color": "#6cb6ffff",
             "font_style": null,
             "font_weight": null
           },

--- a/themes/github_theme.json
+++ b/themes/github_theme.json
@@ -4,373 +4,371 @@
   "author": "Pyae Sone Aung",
   "themes": [
     {
-      "name": "Github Light",
+      "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
       "appearance": "light",
+      "name": "Github Light Default",
       "style": {
-        "border": "#c9c9caff",
-        "border.variant": "#dfdfe0ff",
-        "border.focused": "#cbcdf6ff",
-        "border.selected": "#cbcdf6ff",
-        "border.transparent": "#00000000",
-        "border.disabled": "#d3d3d4ff",
-        "elevated_surface.background": "#ebebecff",
-        "surface.background": "#ebebecff",
-        "background": "#dcdcddff",
-        "element.background": "#ebebecff",
-        "element.hover": "#dfdfe0ff",
-        "element.active": "#cacacaff",
-        "element.selected": "#cacacaff",
-        "element.disabled": "#ebebecff",
-        "drop_target.background": "#7e808780",
-        "ghost_element.background": "#00000000",
-        "ghost_element.hover": "#dfdfe0ff",
-        "ghost_element.active": "#cacacaff",
-        "ghost_element.selected": "#cacacaff",
-        "ghost_element.disabled": "#ebebecff",
-        "text": "#383a41ff",
-        "text.muted": "#7e8087ff",
-        "text.placeholder": "#a1a1a3ff",
-        "text.disabled": "#a1a1a3ff",
-        "text.accent": "#5c78e2ff",
-        "icon": "#383a41ff",
-        "icon.muted": "#7e8087ff",
-        "icon.disabled": "#a1a1a3ff",
-        "icon.placeholder": "#7e8087ff",
-        "icon.accent": "#5c78e2ff",
-        "status_bar.background": "#ffffffff",
-        "title_bar.background": "#ffffffff",
-        "toolbar.background": "#ffffffff",
-        "tab_bar.background": "#ffffffff",
-        "tab.inactive_background": "#f6f8faff",
-        "tab.active_background": "#ffffffff",
-        "search.match_background": "#ffdf5dff",
-        "panel.background": "#f6f8faff",
-        "panel.focused_border": "#e1e4e8ff",
-        "pane.focused_border": null,
-        "scrollbar.thumb.background": "#959da533",
-        "scrollbar.thumb.hover_background": "#959da544",
-        "scrollbar.thumb.border": "#eeeeeeff",
-        "scrollbar.track.background": "#00000000",
-        "scrollbar.track.border": "#eeeeeeff",
-        "editor.foreground": "#24292eff",
+        "background": "#ffffffff",
+        "border": "#d1d9e0ff",
+        "border.disabled": "#818b981a",
+        "border.focused": "#0969daff",
+        "border.selected": "#0969daff",
+        "border.transparent": "#ffffff00",
+        "border.variant": "#d1d9e0b3",
+        "conflict": "#bc4c00ff",
+        "conflict.background": "#fff1e5ff",
+        "conflict.border": "#fb8f4466",
+        "created": "#1a7f37ff",
+        "created.background": "#dafbe1ff",
+        "created.border": "#4ac26b66",
+        "deleted": "#d1242fff",
+        "deleted.background": "#ffebe9ff",
+        "deleted.border": "#ff818266",
+        "drop_target.background": "#ddf4ffff",
+        "editor.active_line.background": "#f6f8faff",
+        "editor.active_line_number": "#1f2328ff",
+        "editor.active_wrap_guide": "#d1d9e0b3",
         "editor.background": "#ffffffff",
+        "editor.document_highlight.read_background": "#ddf4ffff",
+        "editor.document_highlight.write_background": "#0969daff",
+        "editor.foreground": "#1f2328ff",
         "editor.gutter.background": "#ffffffff",
-        "editor.subheader.background": "#ebebecff",
-        "editor.active_line.background": "#f6f8fabf",
-        "editor.highlighted_line.background": "#f6f8faff",
-        "editor.line_number": "#1b1f234d",
-        "editor.active_line_number": "#24292eff",
-        "editor.invisible": "#a3a3a4ff",
-        "editor.wrap_guide": "#383a410d",
-        "editor.active_wrap_guide": "#383a411a",
-        "editor.document_highlight.read_background": "#5c78e21a",
-        "editor.document_highlight.write_background": "#a3a3a466",
-        "terminal.background": "#fafafaff",
-        "terminal.foreground": "#383a41ff",
-        "terminal.bright_foreground": "#383a41ff",
-        "terminal.dim_foreground": "#fafafaff",
-        "terminal.ansi.black": "#fafafaff",
-        "terminal.ansi.bright_black": "#aaaaaaff",
-        "terminal.ansi.dim_black": "#383a41ff",
-        "terminal.ansi.red": "#d36151ff",
-        "terminal.ansi.bright_red": "#f0b0a4ff",
-        "terminal.ansi.dim_red": "#6f312aff",
-        "terminal.ansi.green": "#669f59ff",
-        "terminal.ansi.bright_green": "#b2cfa9ff",
-        "terminal.ansi.dim_green": "#354d2eff",
-        "terminal.ansi.yellow": "#dec184ff",
-        "terminal.ansi.bright_yellow": "#f1dfc1ff",
-        "terminal.ansi.dim_yellow": "#786441ff",
-        "terminal.ansi.blue": "#5c78e2ff",
-        "terminal.ansi.bright_blue": "#b5baf2ff",
-        "terminal.ansi.dim_blue": "#2d3d75ff",
-        "terminal.ansi.magenta": "#984ea5ff",
-        "terminal.ansi.bright_magenta": "#cea6d3ff",
-        "terminal.ansi.dim_magenta": "#4b2a50ff",
-        "terminal.ansi.cyan": "#3a82b7ff",
-        "terminal.ansi.bright_cyan": "#a3bedaff",
-        "terminal.ansi.dim_cyan": "#254058ff",
-        "terminal.ansi.white": "#383a41ff",
-        "terminal.ansi.bright_white": "#383a41ff",
-        "terminal.ansi.dim_white": "#97979aff",
-        "link_text.hover": "#5c78e2ff",
-        "conflict": "#dec184ff",
-        "conflict.background": "#faf2e6ff",
-        "conflict.border": "#f4e7d1ff",
-        "created": "#28a745ff",
-        "created.background": "#dfeadbff",
-        "created.border": "#c8dcc1ff",
-        "deleted": "#d73a49ff",
-        "deleted.background": "#fbdfd9ff",
-        "deleted.border": "#f6c6bdff",
-        "error": "#d36151ff",
-        "error.background": "#fbdfd9ff",
-        "error.border": "#f6c6bdff",
-        "hidden": "#a1a1a3ff",
-        "hidden.background": "#dcdcddff",
-        "hidden.border": "#d3d3d4ff",
-        "hint": "#9294beff",
-        "hint.background": "#e2e2faff",
-        "hint.border": "#cbcdf6ff",
-        "ignored": "#7e8087ff",
-        "ignored.background": "#dcdcddff",
-        "ignored.border": "#c9c9caff",
-        "info": "#5c78e2ff",
-        "info.background": "#e2e2faff",
-        "info.border": "#cbcdf6ff",
-        "modified": "#005cc5ff",
-        "modified.background": "#faf2e6ff",
-        "modified.border": "#f4e7d1ff",
-        "predictive": "#9b9ec6ff",
-        "predictive.background": "#dfeadbff",
-        "predictive.border": "#c8dcc1ff",
-        "renamed": "#5c78e2ff",
-        "renamed.background": "#e2e2faff",
-        "renamed.border": "#cbcdf6ff",
-        "success": "#669f59ff",
-        "success.background": "#dfeadbff",
-        "success.border": "#c8dcc1ff",
-        "unreachable": "#7e8087ff",
-        "unreachable.background": "#dcdcddff",
-        "unreachable.border": "#c9c9caff",
-        "warning": "#dec184ff",
-        "warning.background": "#faf2e6ff",
-        "warning.border": "#f4e7d1ff",
+        "editor.highlighted_line.background": "#818b981f",
+        "editor.invisible": "#818b98ff",
+        "editor.line_number": "#59636eff",
+        "editor.subheader.background": "#f6f8faff",
+        "editor.wrap_guide": "#d1d9e0b3",
+        "element.active": "#818b981f",
+        "element.background": "#818b981f",
+        "element.disabled": "#eff2f5ff",
+        "element.hover": "#818b981f",
+        "element.selected": "#818b981f",
+        "elevated_surface.background": "#f6f8faff",
+        "error": "#d1242fff",
+        "error.background": "#f6f8faff",
+        "error.border": "#d1d9e0b3",
+        "ghost_element.active": "#818b981f",
+        "ghost_element.background": "#ffffff00",
+        "ghost_element.disabled": "#eff2f5ff",
+        "ghost_element.hover": "#ffffffff",
+        "ghost_element.selected": "#818b981f",
+        "hint": "#59636eff",
+        "hint.background": "#f6f8faff",
+        "hint.border": "#d1d9e0b3",
+        "icon": "#1f2328ff",
+        "icon.background": "#ffffffff",
+        "icon.border": "#d1d9e0ff",
+        "icon.accent": "#0969daff",
+        "icon.muted": "#59636eff",
+        "icon.disabled": "#818b98ff",
+        "ignored": "#818b98ff",
+        "ignored.background": "#eff2f5ff",
+        "ignored.border": "#818b981a",
+        "info": "#9a6700ff",
+        "info.background": "#f6f8faff",
+        "info.border": "#d1d9e0b3",
+        "link_text.hover": "#0969daff",
+        "modified": "#9a6700ff",
+        "modified.background": "#fff8c5ff",
+        "modified.border": "#d4a72c66",
+        "pane.focused_border": "#d1d9e0ff",
+        "panel.background": "#f6f8faff",
+        "panel.focused_border": "#d1d9e0ff",
+        "predictive.background": "#818b981f",
+        "predictive.border": "#d1d9e0b3",
+        "renamed": "#1a7f37ff",
+        "renamed.background": "#dafbe1ff",
+        "renamed.border": "#4ac26b66",
+        "scrollbar.thumb.border": "#ffffff00",
+        "scrollbar.thumb.hover_background": "#f6f8faff",
+        "scrollbar.track.background": "#ffffff00",
+        "scrollbar.track.border": "#ffffff00",
+        "search.match_background": "#fff8c5ff",
+        "status_bar.background": "#f6f8faff",
+        "success": "#1a7f37ff",
+        "success.background": "#dafbe1ff",
+        "success.border": "#4ac26b66",
+        "surface.background": "#f6f8faff",
+        "tab.active_background": "#ffffffff",
+        "tab.inactive_background": "#f6f8faff",
+        "tab_bar.background": "#f6f8faff",
+        "terminal.ansi.black": "#1f2328ff",
+        "terminal.ansi.bright_black": "#393f46ff",
+        "terminal.ansi.dim_black": "#1f2328ff",
+        "terminal.ansi.blue": "#0969daff",
+        "terminal.ansi.bright_blue": "#218bffff",
+        "terminal.ansi.dim_blue": "#0969daff",
+        "terminal.ansi.cyan": "#1b7c83ff",
+        "terminal.ansi.bright_cyan": "#3192aaff",
+        "terminal.ansi.dim_cyan": "#1b7c83ff",
+        "terminal.ansi.green": "#116329ff",
+        "terminal.ansi.bright_green": "#1a7f37ff",
+        "terminal.ansi.dim_green": "#116329ff",
+        "terminal.ansi.magenta": "#8250dfff",
+        "terminal.ansi.bright_magenta": "#a475f9ff",
+        "terminal.ansi.dim_magenta": "#8250dfff",
+        "terminal.ansi.red": "#cf222eff",
+        "terminal.ansi.bright_red": "#a40e26ff",
+        "terminal.ansi.dim_red": "#cf222eff",
+        "terminal.ansi.white": "#59636eff",
+        "terminal.ansi.bright_white": "#818b98ff",
+        "terminal.ansi.dim_white": "#59636eff",
+        "terminal.ansi.yellow": "#4d2d00ff",
+        "terminal.ansi.bright_yellow": "#633c01ff",
+        "terminal.ansi.dim_yellow": "#4d2d00ff",
+        "terminal.background": "#f6f8faff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#1f2328ff",
+        "terminal.foreground": "#59636eff",
+        "text": "#1f2328ff",
+        "text.accent": "#0969daff",
+        "text.disabled": "#818b98ff",
+        "text.muted": "#59636eff",
+        "title_bar.background": "#f6f8faff",
+        "toolbar.background": "#ffffffff",
+        "unreachable": "#818b98ff",
+        "unreachable.background": "#eff2f5ff",
+        "unreachable.border": "#818b981a",
+        "warning": "#9a6700ff",
+        "warning.background": "#f6f8faff",
+        "warning.border": "#d1d9e0b3",
         "players": [
           {
-            "cursor": "#5c78e2ff",
-            "background": "#5c78e2ff",
-            "selection": "#5c78e23d"
+            "background": "#d1f0ffff",
+            "border": "#d1f0ffff"
           },
           {
-            "cursor": "#984ea5ff",
-            "background": "#984ea5ff",
-            "selection": "#984ea53d"
+            "background": "#ffe7d1ff",
+            "border": "#ffe7d1ff"
           },
           {
-            "cursor": "#ad6e26ff",
-            "background": "#ad6e26ff",
-            "selection": "#ad6e263d"
+            "background": "#ffe5f1ff",
+            "border": "#ffe5f1ff"
           },
           {
-            "cursor": "#a349abff",
-            "background": "#a349abff",
-            "selection": "#a349ab3d"
+            "background": "#caf7caff",
+            "border": "#caf7caff"
           },
           {
-            "cursor": "#3a82b7ff",
-            "background": "#3a82b7ff",
-            "selection": "#3a82b73d"
+            "background": "#f1e5ffff",
+            "border": "#f1e5ffff"
           },
           {
-            "cursor": "#d36151ff",
-            "background": "#d36151ff",
-            "selection": "#d361513d"
+            "background": "#ffec9eff",
+            "border": "#ffec9eff"
           },
           {
-            "cursor": "#dec184ff",
-            "background": "#dec184ff",
-            "selection": "#dec1843d"
+            "background": "#c7f5efff",
+            "border": "#c7f5efff"
           },
           {
-            "cursor": "#669f59ff",
-            "background": "#669f59ff",
-            "selection": "#669f593d"
+            "background": "#ffe2e0ff",
+            "border": "#ffe2e0ff"
           }
         ],
         "syntax": {
           "attribute": {
-            "color": "#5c78e2ff",
+            "color": null,
             "font_style": null,
             "font_weight": null
           },
           "boolean": {
-            "color": "#ad6e25ff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "comment": {
-            "color": "#6a737dff",
+            "color": "#59636eff",
             "font_style": null,
             "font_weight": null
           },
           "comment.doc": {
-            "color": "#6a737dff",
+            "color": "#59636eff",
             "font_style": null,
             "font_weight": null
           },
           "constant": {
-            "color": "#005cc5ff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "constructor": {
-            "color": "#005cc5ff",
+            "color": "#953800ff",
             "font_style": null,
             "font_weight": null
           },
           "embedded": {
-            "color": "#032f62ff",
+            "color": "#cf222eff",
             "font_style": null,
             "font_weight": null
           },
           "emphasis": {
-            "color": "#5c78e2ff",
-            "font_style": null,
+            "color": null,
+            "font_style": "italic",
             "font_weight": null
           },
           "emphasis.strong": {
-            "color": "#ad6e25ff",
+            "color": null,
             "font_style": null,
             "font_weight": 700
           },
           "enum": {
-            "color": "#005cc5ff",
+            "color": "#953800ff",
             "font_style": null,
             "font_weight": null
           },
           "function": {
-            "color": "#6f42c1ff",
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#8250dfff",
             "font_style": null,
             "font_weight": null
           },
           "hint": {
-            "color": "#9294beff",
+            "color": "fgColor/muted",
             "font_style": null,
             "font_weight": 700
           },
           "keyword": {
-            "color": "#d73a49ff",
+            "color": "#cf222eff",
             "font_style": null,
             "font_weight": null
           },
           "label": {
-            "color": "#5c78e2ff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "link_text": {
-            "color": "#5b79e3ff",
+            "color": "#0a3069ff",
             "font_style": "italic",
             "font_weight": null
           },
           "link_uri": {
-            "color": "#3882b7ff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "number": {
-            "color": "#005cc5ff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "operator": {
-            "color": "#24292eff",
+            "color": "fgColor/default",
             "font_style": null,
             "font_weight": null
           },
           "predictive": {
-            "color": "#9b9ec6ff",
+            "color": "fgColor/placeholder",
             "font_style": "italic",
             "font_weight": null
           },
           "preproc": {
-            "color": "#383a41ff",
+            "color": "#cf222eff",
             "font_style": null,
             "font_weight": null
           },
           "primary": {
-            "color": "#383a41ff",
+            "color": "fgColor/default",
             "font_style": null,
             "font_weight": null
           },
           "property": {
-            "color": "#005cc5ff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation": {
-            "color": "#383a41ff",
+            "color": "fgColor/default",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.bracket": {
-            "color": "#4d4f52ff",
+            "color": "fgColor/default",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.delimiter": {
-            "color": "#4d4f52ff",
+            "color": "fgColor/default",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.list_marker": {
-            "color": "#d3604fff",
+            "color": "#953800ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
-            "color": "#b92b46ff",
+            "color": "#cf222eff",
             "font_style": null,
             "font_weight": null
           },
           "string": {
-            "color": "#032f62ff",
+            "color": "#0a3069ff",
             "font_style": null,
             "font_weight": null
           },
           "string.escape": {
-            "color": "#7c7e86ff",
-            "font_style": null,
+            "color": "#116329ff",
+            "font_style": "bold",
             "font_weight": null
           },
           "string.regex": {
-            "color": "#ad6e26ff",
+            "color": "#0a3069ff",
             "font_style": null,
             "font_weight": null
           },
           "string.special": {
-            "color": "#ad6e26ff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "string.special.symbol": {
-            "color": "#ad6e26ff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "tag": {
-            "color": "#22863aff",
+            "color": "#116329ff",
             "font_style": null,
             "font_weight": null
           },
           "text.literal": {
-            "color": "#649f57ff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "title": {
-            "color": "#d3604fff",
+            "color": "#0550aeff",
             "font_style": null,
-            "font_weight": 400
+            "font_weight": 700
           },
           "type": {
-            "color": "#24292eff",
+            "color": "#953800ff",
             "font_style": null,
             "font_weight": null
           },
           "variable": {
-            "color": "#24292eff",
+            "color": "#953800ff",
             "font_style": null,
             "font_weight": null
           },
           "variable.special": {
-            "color": "#ad6e25ff",
+            "color": "#cf222eff",
             "font_style": null,
             "font_weight": null
           },
           "variant": {
-            "color": "#5b79e3ff",
+            "color": "#953800ff",
             "font_style": null,
             "font_weight": null
           }
@@ -378,373 +376,2975 @@
       }
     },
     {
-      "name": "Github Dark",
-      "appearance": "dark",
+      "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+      "appearance": "light",
+      "name": "Github Light Colorblind",
       "style": {
-        "border": "#464b57ff",
-        "border.variant": "#363c46ff",
-        "border.focused": "#293b5bff",
-        "border.selected": "#293b5bff",
-        "border.transparent": "#00000000",
-        "border.disabled": "#414754ff",
-        "elevated_surface.background": "#2f343eff",
-        "surface.background": "#2f343eff",
-        "background": "#3b414dff",
-        "element.background": "#2f343eff",
-        "element.hover": "#363c46ff",
-        "element.active": "#454a56ff",
-        "element.selected": "#454a56ff",
-        "element.disabled": "#2f343eff",
-        "drop_target.background": "#83899480",
-        "ghost_element.background": "#00000000",
-        "ghost_element.hover": "#363c46ff",
-        "ghost_element.active": "#454a56ff",
-        "ghost_element.selected": "#454a56ff",
-        "ghost_element.disabled": "#2f343eff",
-        "text": "#c8ccd4ff",
-        "text.muted": "#838994ff",
-        "text.placeholder": "#555a63ff",
-        "text.disabled": "#555a63ff",
-        "text.accent": "#74ade8ff",
-        "icon": "#c8ccd4ff",
-        "icon.muted": "#838994ff",
-        "icon.disabled": "#555a63ff",
-        "icon.placeholder": "#838994ff",
-        "icon.accent": "#74ade8ff",
-        "status_bar.background": "#24292eff",
-        "title_bar.background": "#24292eff",
-        "toolbar.background": "#24292eff",
-        "tab_bar.background": "#1f2428ff",
-        "tab.inactive_background": "#1f2428ff",
-        "tab.active_background": "#24292eff",
-        "search.match_background": "#ffd33d44",
-        "panel.background": "#1f2428ff",
-        "panel.focused_border": "#1b1f23ff",
-        "pane.focused_border": null,
-        "scrollbar.thumb.background": "#6a737d33",
-        "scrollbar.thumb.hover_background": "#6a737d44",
-        "scrollbar.thumb.border": "#363c46ff",
-        "scrollbar.track.background": "#00000000",
-        "scrollbar.track.border": "#2e333cff",
-        "editor.foreground": "#e1e4e8ff",
-        "editor.background": "#24292eff",
-        "editor.gutter.background": "#24292eff",
-        "editor.subheader.background": "#2f343eff",
-        "editor.active_line.background": "#2b3036bf",
-        "editor.highlighted_line.background": "#2b3036ff",
-        "editor.line_number": "#e1e4e859",
-        "editor.active_line_number": "#e1e4e8ff",
-        "editor.invisible": "#555a63ff",
-        "editor.wrap_guide": "#c8ccd40d",
-        "editor.active_wrap_guide": "#c8ccd41a",
-        "editor.document_highlight.read_background": "#74ade81a",
-        "editor.document_highlight.write_background": "#555a6366",
-        "terminal.background": "#282c33ff",
-        "terminal.foreground": "#c8ccd4ff",
-        "terminal.bright_foreground": "#c8ccd4ff",
-        "terminal.dim_foreground": "#282c33ff",
-        "terminal.ansi.black": "#282c33ff",
-        "terminal.ansi.bright_black": "#525561ff",
-        "terminal.ansi.dim_black": "#c8ccd4ff",
-        "terminal.ansi.red": "#d07277ff",
-        "terminal.ansi.bright_red": "#673a3cff",
-        "terminal.ansi.dim_red": "#eab7b9ff",
-        "terminal.ansi.green": "#a1c181ff",
-        "terminal.ansi.bright_green": "#4d6140ff",
-        "terminal.ansi.dim_green": "#d1e0bfff",
-        "terminal.ansi.yellow": "#dec184ff",
-        "terminal.ansi.bright_yellow": "#786441ff",
-        "terminal.ansi.dim_yellow": "#f1dfc1ff",
-        "terminal.ansi.blue": "#74ade8ff",
-        "terminal.ansi.bright_blue": "#385378ff",
-        "terminal.ansi.dim_blue": "#bed5f4ff",
-        "terminal.ansi.magenta": "#be5046ff",
-        "terminal.ansi.bright_magenta": "#5e2b26ff",
-        "terminal.ansi.dim_magenta": "#e6a79eff",
-        "terminal.ansi.cyan": "#6eb4bfff",
-        "terminal.ansi.bright_cyan": "#3a565bff",
-        "terminal.ansi.dim_cyan": "#b9d9dfff",
-        "terminal.ansi.white": "#c8ccd4ff",
-        "terminal.ansi.bright_white": "#c8ccd4ff",
-        "terminal.ansi.dim_white": "#575d65ff",
-        "link_text.hover": "#74ade8ff",
-        "conflict": "#dec184ff",
-        "conflict.background": "#41321dff",
-        "conflict.border": "#5d4c2fff",
-        "created": "#34d058ff",
-        "created.background": "#222e1dff",
-        "created.border": "#38482fff",
-        "deleted": "#ea4a5aff",
-        "deleted.background": "#301b1bff",
-        "deleted.border": "#4c2b2cff",
-        "error": "#d07277ff",
-        "error.background": "#301b1bff",
-        "error.border": "#4c2b2cff",
-        "hidden": "#555a63ff",
-        "hidden.background": "#3b414dff",
-        "hidden.border": "#414754ff",
-        "hint": "#5a6f89ff",
-        "hint.background": "#18243dff",
-        "hint.border": "#293b5bff",
-        "ignored": "#838994ff",
-        "ignored.background": "#3b414dff",
-        "ignored.border": "#464b57ff",
-        "info": "#74ade8ff",
-        "info.background": "#18243dff",
-        "info.border": "#293b5bff",
-        "modified": "#79b8ffff",
-        "modified.background": "#41321dff",
-        "modified.border": "#5d4c2fff",
-        "predictive": "#5a6a87ff",
-        "predictive.background": "#222e1dff",
-        "predictive.border": "#38482fff",
-        "renamed": "#74ade8ff",
-        "renamed.background": "#18243dff",
-        "renamed.border": "#293b5bff",
-        "success": "#a1c181ff",
-        "success.background": "#222e1dff",
-        "success.border": "#38482fff",
-        "unreachable": "#838994ff",
-        "unreachable.background": "#3b414dff",
-        "unreachable.border": "#464b57ff",
-        "warning": "#dec184ff",
-        "warning.background": "#41321dff",
-        "warning.border": "#5d4c2fff",
+        "background": "#ffffffff",
+        "border": "#d1d9e0ff",
+        "border.disabled": "#818b981a",
+        "border.focused": "#0969daff",
+        "border.selected": "#0969daff",
+        "border.transparent": "#ffffff00",
+        "border.variant": "#d1d9e0b3",
+        "conflict": "#bc4c00ff",
+        "conflict.background": "#fff1e5ff",
+        "conflict.border": "#fb8f4466",
+        "created": "#0969daff",
+        "created.background": "#ddf4ffff",
+        "created.border": "#54aeff66",
+        "deleted": "#be4e02ff",
+        "deleted.background": "#fff1e5ff",
+        "deleted.border": "#fb8f4466",
+        "drop_target.background": "#ddf4ffff",
+        "editor.active_line.background": "#f6f8faff",
+        "editor.active_line_number": "#1f2328ff",
+        "editor.active_wrap_guide": "#d1d9e0b3",
+        "editor.background": "#ffffffff",
+        "editor.document_highlight.read_background": "#ddf4ffff",
+        "editor.document_highlight.write_background": "#0969daff",
+        "editor.foreground": "#1f2328ff",
+        "editor.gutter.background": "#ffffffff",
+        "editor.highlighted_line.background": "#818b981f",
+        "editor.invisible": "#818b98ff",
+        "editor.line_number": "#59636eff",
+        "editor.subheader.background": "#f6f8faff",
+        "editor.wrap_guide": "#d1d9e0b3",
+        "element.active": "#818b981f",
+        "element.background": "#818b981f",
+        "element.disabled": "#eff2f5ff",
+        "element.hover": "#818b981f",
+        "element.selected": "#818b981f",
+        "elevated_surface.background": "#f6f8faff",
+        "error": "#be4e02ff",
+        "error.background": "#f6f8faff",
+        "error.border": "#d1d9e0b3",
+        "ghost_element.active": "#818b981f",
+        "ghost_element.background": "#ffffff00",
+        "ghost_element.disabled": "#eff2f5ff",
+        "ghost_element.hover": "#ffffffff",
+        "ghost_element.selected": "#818b981f",
+        "hint": "#59636eff",
+        "hint.background": "#f6f8faff",
+        "hint.border": "#d1d9e0b3",
+        "icon": "#1f2328ff",
+        "icon.background": "#ffffffff",
+        "icon.border": "#d1d9e0ff",
+        "icon.accent": "#0969daff",
+        "icon.muted": "#59636eff",
+        "icon.disabled": "#818b98ff",
+        "ignored": "#818b98ff",
+        "ignored.background": "#eff2f5ff",
+        "ignored.border": "#818b981a",
+        "info": "#9a6700ff",
+        "info.background": "#f6f8faff",
+        "info.border": "#d1d9e0b3",
+        "link_text.hover": "#0969daff",
+        "modified": "#9a6700ff",
+        "modified.background": "#fff8c5ff",
+        "modified.border": "#d4a72c66",
+        "pane.focused_border": "#d1d9e0ff",
+        "panel.background": "#f6f8faff",
+        "panel.focused_border": "#d1d9e0ff",
+        "predictive.background": "#818b981f",
+        "predictive.border": "#d1d9e0b3",
+        "renamed": "#0969daff",
+        "renamed.background": "#ddf4ffff",
+        "renamed.border": "#54aeff66",
+        "scrollbar.thumb.border": "#ffffff00",
+        "scrollbar.thumb.hover_background": "#f6f8faff",
+        "scrollbar.track.background": "#ffffff00",
+        "scrollbar.track.border": "#ffffff00",
+        "search.match_background": "#fff8c5ff",
+        "status_bar.background": "#f6f8faff",
+        "success": "#0969daff",
+        "success.background": "#ddf4ffff",
+        "success.border": "#54aeff66",
+        "surface.background": "#f6f8faff",
+        "tab.active_background": "#ffffffff",
+        "tab.inactive_background": "#f6f8faff",
+        "tab_bar.background": "#f6f8faff",
+        "terminal.ansi.black": "#1f2328ff",
+        "terminal.ansi.bright_black": "#393f46ff",
+        "terminal.ansi.dim_black": "#1f2328ff",
+        "terminal.ansi.blue": "#0969daff",
+        "terminal.ansi.bright_blue": "#218bffff",
+        "terminal.ansi.dim_blue": "#0969daff",
+        "terminal.ansi.cyan": "#1b7c83ff",
+        "terminal.ansi.bright_cyan": "#3192aaff",
+        "terminal.ansi.dim_cyan": "#1b7c83ff",
+        "terminal.ansi.green": "#0550aeff",
+        "terminal.ansi.bright_green": "#0969daff",
+        "terminal.ansi.dim_green": "#0550aeff",
+        "terminal.ansi.magenta": "#8250dfff",
+        "terminal.ansi.bright_magenta": "#a475f9ff",
+        "terminal.ansi.dim_magenta": "#8250dfff",
+        "terminal.ansi.red": "#bc4c00ff",
+        "terminal.ansi.bright_red": "#953800ff",
+        "terminal.ansi.dim_red": "#bc4c00ff",
+        "terminal.ansi.white": "#59636eff",
+        "terminal.ansi.bright_white": "#818b98ff",
+        "terminal.ansi.dim_white": "#59636eff",
+        "terminal.ansi.yellow": "#4d2d00ff",
+        "terminal.ansi.bright_yellow": "#633c01ff",
+        "terminal.ansi.dim_yellow": "#4d2d00ff",
+        "terminal.background": "#f6f8faff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#1f2328ff",
+        "terminal.foreground": "#59636eff",
+        "text": "#1f2328ff",
+        "text.accent": "#0969daff",
+        "text.disabled": "#818b98ff",
+        "text.muted": "#59636eff",
+        "title_bar.background": "#f6f8faff",
+        "toolbar.background": "#ffffffff",
+        "unreachable": "#818b98ff",
+        "unreachable.background": "#eff2f5ff",
+        "unreachable.border": "#818b981a",
+        "warning": "#9a6700ff",
+        "warning.background": "#f6f8faff",
+        "warning.border": "#d1d9e0b3",
         "players": [
           {
-            "cursor": "#74ade8ff",
-            "background": "#74ade8ff",
-            "selection": "#74ade83d"
+            "background": "#d1f0ffff",
+            "border": "#d1f0ffff"
           },
           {
-            "cursor": "#be5046ff",
-            "background": "#be5046ff",
-            "selection": "#be50463d"
+            "background": "#ffe7d1ff",
+            "border": "#ffe7d1ff"
           },
           {
-            "cursor": "#bf956aff",
-            "background": "#bf956aff",
-            "selection": "#bf956a3d"
+            "background": "#ffe5f1ff",
+            "border": "#ffe5f1ff"
           },
           {
-            "cursor": "#b477cfff",
-            "background": "#b477cfff",
-            "selection": "#b477cf3d"
+            "background": "#caf7caff",
+            "border": "#caf7caff"
           },
           {
-            "cursor": "#6eb4bfff",
-            "background": "#6eb4bfff",
-            "selection": "#6eb4bf3d"
+            "background": "#f1e5ffff",
+            "border": "#f1e5ffff"
           },
           {
-            "cursor": "#d07277ff",
-            "background": "#d07277ff",
-            "selection": "#d072773d"
+            "background": "#ffec9eff",
+            "border": "#ffec9eff"
           },
           {
-            "cursor": "#dec184ff",
-            "background": "#dec184ff",
-            "selection": "#dec1843d"
+            "background": "#c7f5efff",
+            "border": "#c7f5efff"
           },
           {
-            "cursor": "#a1c181ff",
-            "background": "#a1c181ff",
-            "selection": "#a1c1813d"
+            "background": "#ffe2e0ff",
+            "border": "#ffe2e0ff"
           }
         ],
         "syntax": {
           "attribute": {
-            "color": "#74ade8ff",
+            "color": null,
             "font_style": null,
             "font_weight": null
           },
           "boolean": {
-            "color": "#bf956aff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "comment": {
-            "color": "#6a737dff",
+            "color": "#59636eff",
             "font_style": null,
             "font_weight": null
           },
           "comment.doc": {
-            "color": "#6a737dff",
+            "color": "#59636eff",
             "font_style": null,
             "font_weight": null
           },
           "constant": {
-            "color": "#79b8ffff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "constructor": {
-            "color": "#79b8ffff",
+            "color": "#953800ff",
             "font_style": null,
             "font_weight": null
           },
           "embedded": {
-            "color": "#9ecbffff",
+            "color": "#cf222eff",
             "font_style": null,
             "font_weight": null
           },
           "emphasis": {
-            "color": "#74ade8ff",
-            "font_style": null,
+            "color": null,
+            "font_style": "italic",
             "font_weight": null
           },
           "emphasis.strong": {
-            "color": "#bf956aff",
+            "color": null,
             "font_style": null,
             "font_weight": 700
           },
           "enum": {
-            "color": "#d07277ff",
+            "color": "#953800ff",
             "font_style": null,
             "font_weight": null
           },
           "function": {
-            "color": "#b392f0ff",
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#8250dfff",
             "font_style": null,
             "font_weight": null
           },
           "hint": {
-            "color": "#5a6f89ff",
+            "color": "fgColor/muted",
             "font_style": null,
             "font_weight": 700
           },
           "keyword": {
-            "color": "#f97583ff",
+            "color": "#cf222eff",
             "font_style": null,
             "font_weight": null
           },
           "label": {
-            "color": "#74ade8ff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "link_text": {
-            "color": "#73ade9ff",
-            "font_style": "normal",
+            "color": "#0a3069ff",
+            "font_style": "italic",
             "font_weight": null
           },
           "link_uri": {
-            "color": "#6eb4bfff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "number": {
-            "color": "#79b8ffff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "operator": {
-            "color": "#e1e4e8ff",
+            "color": "fgColor/default",
             "font_style": null,
             "font_weight": null
           },
           "predictive": {
-            "color": "#5a6a87ff",
+            "color": "fgColor/placeholder",
             "font_style": "italic",
             "font_weight": null
           },
           "preproc": {
-            "color": "#c8ccd4ff",
+            "color": "#cf222eff",
             "font_style": null,
             "font_weight": null
           },
           "primary": {
-            "color": "#acb2beff",
+            "color": "fgColor/default",
             "font_style": null,
             "font_weight": null
           },
           "property": {
-            "color": "#79b8ffff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation": {
-            "color": "#acb2beff",
+            "color": "fgColor/default",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.bracket": {
-            "color": "#b2b9c6ff",
+            "color": "fgColor/default",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.delimiter": {
-            "color": "#b2b9c6ff",
+            "color": "fgColor/default",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.list_marker": {
-            "color": "#d07277ff",
+            "color": "#953800ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
-            "color": "#b1574bff",
+            "color": "#cf222eff",
             "font_style": null,
             "font_weight": null
           },
           "string": {
-            "color": "#79b8ffff",
+            "color": "#0a3069ff",
             "font_style": null,
             "font_weight": null
           },
           "string.escape": {
-            "color": "#878e98ff",
-            "font_style": null,
+            "color": "#116329ff",
+            "font_style": "bold",
             "font_weight": null
           },
           "string.regex": {
-            "color": "#bf956aff",
+            "color": "#0a3069ff",
             "font_style": null,
             "font_weight": null
           },
           "string.special": {
-            "color": "#bf956aff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "string.special.symbol": {
-            "color": "#bf956aff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "tag": {
-            "color": "#e1e4e8ff",
+            "color": "#116329ff",
             "font_style": null,
             "font_weight": null
           },
           "text.literal": {
-            "color": "#a1c181ff",
+            "color": "#0550aeff",
             "font_style": null,
             "font_weight": null
           },
           "title": {
-            "color": "#d07277ff",
+            "color": "#0550aeff",
             "font_style": null,
-            "font_weight": 400
+            "font_weight": 700
           },
           "type": {
-            "color": "#e1e4e8ff",
+            "color": "#953800ff",
             "font_style": null,
             "font_weight": null
           },
           "variable": {
-            "color": "#e1e4e8ff",
+            "color": "#953800ff",
             "font_style": null,
             "font_weight": null
           },
           "variable.special": {
-            "color": "#bf956aff",
+            "color": "#cf222eff",
             "font_style": null,
             "font_weight": null
           },
           "variant": {
-            "color": "#73ade9ff",
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+      "appearance": "light",
+      "name": "Github Light High Contrast",
+      "style": {
+        "background": "#ffffffff",
+        "border": "#454c54ff",
+        "border.disabled": "#59636e1f",
+        "border.focused": "#0349b4ff",
+        "border.selected": "#0349b4ff",
+        "border.transparent": "#ffffff00",
+        "border.variant": "#454c54ff",
+        "conflict": "#702c00ff",
+        "conflict.background": "#fff2d5ff",
+        "conflict.border": "#dc6d1aff",
+        "created": "#024c1aff",
+        "created.background": "#d2fedbff",
+        "created.border": "#26a148ff",
+        "deleted": "#8a071eff",
+        "deleted.background": "#fff0eeff",
+        "deleted.border": "#ee5a5dff",
+        "drop_target.background": "#dff7ffff",
+        "editor.active_line.background": "#e6eaefff",
+        "editor.active_line_number": "#010409ff",
+        "editor.active_wrap_guide": "#454c54ff",
+        "editor.background": "#ffffffff",
+        "editor.document_highlight.read_background": "#dff7ffff",
+        "editor.document_highlight.write_background": "#0349b4ff",
+        "editor.foreground": "#010409ff",
+        "editor.gutter.background": "#ffffffff",
+        "editor.highlighted_line.background": "#e0e6ebff",
+        "editor.invisible": "#59636eff",
+        "editor.line_number": "#454c54ff",
+        "editor.subheader.background": "#e6eaefff",
+        "editor.wrap_guide": "#454c54ff",
+        "element.active": "#e0e6ebff",
+        "element.background": "#e0e6ebff",
+        "element.disabled": "#e0e6ebff",
+        "element.hover": "#e0e6ebff",
+        "element.selected": "#e0e6ebff",
+        "elevated_surface.background": "#e6eaefff",
+        "error": "#8a071eff",
+        "error.background": "#e6eaefff",
+        "error.border": "#454c54ff",
+        "ghost_element.active": "#e0e6ebff",
+        "ghost_element.background": "#ffffff00",
+        "ghost_element.disabled": "#e0e6ebff",
+        "ghost_element.hover": "#ffffffff",
+        "ghost_element.selected": "#e0e6ebff",
+        "hint": "#454c54ff",
+        "hint.background": "#e6eaefff",
+        "hint.border": "#454c54ff",
+        "icon": "#010409ff",
+        "icon.background": "#ffffffff",
+        "icon.border": "#454c54ff",
+        "icon.accent": "#023b95ff",
+        "icon.muted": "#454c54ff",
+        "icon.disabled": "#59636eff",
+        "ignored": "#59636eff",
+        "ignored.background": "#e0e6ebff",
+        "ignored.border": "#59636e1f",
+        "info": "#603700ff",
+        "info.background": "#e6eaefff",
+        "info.border": "#454c54ff",
+        "link_text.hover": "#023b95ff",
+        "modified": "#603700ff",
+        "modified.background": "#fcf7beff",
+        "modified.border": "#b58407ff",
+        "pane.focused_border": "#454c54ff",
+        "panel.background": "#eff2f5ff",
+        "panel.focused_border": "#454c54ff",
+        "predictive.background": "#e0e6ebff",
+        "predictive.border": "#454c54ff",
+        "renamed": "#024c1aff",
+        "renamed.background": "#d2fedbff",
+        "renamed.border": "#26a148ff",
+        "scrollbar.thumb.border": "#ffffff00",
+        "scrollbar.thumb.hover_background": "#e6eaefff",
+        "scrollbar.track.background": "#ffffff00",
+        "scrollbar.track.border": "#ffffff00",
+        "search.match_background": "#fcf7beff",
+        "status_bar.background": "#eff2f5ff",
+        "success": "#024c1aff",
+        "success.background": "#d2fedbff",
+        "success.border": "#26a148ff",
+        "surface.background": "#eff2f5ff",
+        "tab.active_background": "#ffffffff",
+        "tab.inactive_background": "#eff2f5ff",
+        "tab_bar.background": "#eff2f5ff",
+        "terminal.ansi.black": "#010409ff",
+        "terminal.ansi.bright_black": "#393f46ff",
+        "terminal.ansi.dim_black": "#010409ff",
+        "terminal.ansi.blue": "#0349b4ff",
+        "terminal.ansi.bright_blue": "#1168e3ff",
+        "terminal.ansi.dim_blue": "#0349b4ff",
+        "terminal.ansi.cyan": "#1b7c83ff",
+        "terminal.ansi.bright_cyan": "#3192aaff",
+        "terminal.ansi.dim_cyan": "#1b7c83ff",
+        "terminal.ansi.green": "#024c1aff",
+        "terminal.ansi.bright_green": "#055d20ff",
+        "terminal.ansi.dim_green": "#024c1aff",
+        "terminal.ansi.magenta": "#622cbcff",
+        "terminal.ansi.bright_magenta": "#844ae7ff",
+        "terminal.ansi.dim_magenta": "#622cbcff",
+        "terminal.ansi.red": "#a0111fff",
+        "terminal.ansi.bright_red": "#86061dff",
+        "terminal.ansi.dim_red": "#a0111fff",
+        "terminal.ansi.white": "#59636eff",
+        "terminal.ansi.bright_white": "#818b98ff",
+        "terminal.ansi.dim_white": "#59636eff",
+        "terminal.ansi.yellow": "#3f2200ff",
+        "terminal.ansi.bright_yellow": "#4e2c00ff",
+        "terminal.ansi.dim_yellow": "#3f2200ff",
+        "terminal.background": "#eff2f5ff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#010409ff",
+        "terminal.foreground": "#454c54ff",
+        "text": "#010409ff",
+        "text.accent": "#023b95ff",
+        "text.disabled": "#59636eff",
+        "text.muted": "#454c54ff",
+        "title_bar.background": "#eff2f5ff",
+        "toolbar.background": "#ffffffff",
+        "unreachable": "#59636eff",
+        "unreachable.background": "#e0e6ebff",
+        "unreachable.border": "#59636e1f",
+        "warning": "#603700ff",
+        "warning.background": "#e6eaefff",
+        "warning.border": "#454c54ff",
+        "players": [
+          {
+            "background": "#d1f0ffff",
+            "border": "#d1f0ffff"
+          },
+          {
+            "background": "#ffe7d1ff",
+            "border": "#ffe7d1ff"
+          },
+          {
+            "background": "#ffe5f1ff",
+            "border": "#ffe5f1ff"
+          },
+          {
+            "background": "#caf7caff",
+            "border": "#caf7caff"
+          },
+          {
+            "background": "#f1e5ffff",
+            "border": "#f1e5ffff"
+          },
+          {
+            "background": "#ffec9eff",
+            "border": "#ffec9eff"
+          },
+          {
+            "background": "#c7f5efff",
+            "border": "#c7f5efff"
+          },
+          {
+            "background": "#ffe2e0ff",
+            "border": "#ffe2e0ff"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#59636eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#59636eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#702c00ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#a0111fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#702c00ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#622cbcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#622cbcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#622cbcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "fgColor/muted",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#a0111fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#032563ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "fgColor/placeholder",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#a0111fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#702c00ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#a0111fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#032563ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#024c1aff",
+            "font_style": "bold",
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#032563ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#024c1aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#702c00ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#702c00ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#a0111fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#702c00ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+      "appearance": "light",
+      "name": "Github Light Tritanopia",
+      "style": {
+        "background": "#ffffffff",
+        "border": "#d1d9e0ff",
+        "border.disabled": "#818b981a",
+        "border.focused": "#0969daff",
+        "border.selected": "#0969daff",
+        "border.transparent": "#ffffff00",
+        "border.variant": "#d1d9e0b3",
+        "conflict": "#cf222eff",
+        "conflict.background": "#ffebe9ff",
+        "conflict.border": "#ff818266",
+        "created": "#0969daff",
+        "created.background": "#ddf4ffff",
+        "created.border": "#54aeff66",
+        "deleted": "#d1242fff",
+        "deleted.background": "#ffebe9ff",
+        "deleted.border": "#ff818266",
+        "drop_target.background": "#ddf4ffff",
+        "editor.active_line.background": "#f6f8faff",
+        "editor.active_line_number": "#1f2328ff",
+        "editor.active_wrap_guide": "#d1d9e0b3",
+        "editor.background": "#ffffffff",
+        "editor.document_highlight.read_background": "#ddf4ffff",
+        "editor.document_highlight.write_background": "#0969daff",
+        "editor.foreground": "#1f2328ff",
+        "editor.gutter.background": "#ffffffff",
+        "editor.highlighted_line.background": "#818b981f",
+        "editor.invisible": "#818b98ff",
+        "editor.line_number": "#59636eff",
+        "editor.subheader.background": "#f6f8faff",
+        "editor.wrap_guide": "#d1d9e0b3",
+        "element.active": "#818b981f",
+        "element.background": "#818b981f",
+        "element.disabled": "#eff2f5ff",
+        "element.hover": "#818b981f",
+        "element.selected": "#818b981f",
+        "elevated_surface.background": "#f6f8faff",
+        "error": "#d1242fff",
+        "error.background": "#f6f8faff",
+        "error.border": "#d1d9e0b3",
+        "ghost_element.active": "#818b981f",
+        "ghost_element.background": "#ffffff00",
+        "ghost_element.disabled": "#eff2f5ff",
+        "ghost_element.hover": "#ffffffff",
+        "ghost_element.selected": "#818b981f",
+        "hint": "#59636eff",
+        "hint.background": "#f6f8faff",
+        "hint.border": "#d1d9e0b3",
+        "icon": "#1f2328ff",
+        "icon.background": "#ffffffff",
+        "icon.border": "#d1d9e0ff",
+        "icon.accent": "#0969daff",
+        "icon.muted": "#59636eff",
+        "icon.disabled": "#818b98ff",
+        "ignored": "#818b98ff",
+        "ignored.background": "#eff2f5ff",
+        "ignored.border": "#818b981a",
+        "info": "#9a6700ff",
+        "info.background": "#f6f8faff",
+        "info.border": "#d1d9e0b3",
+        "link_text.hover": "#0969daff",
+        "modified": "#9a6700ff",
+        "modified.background": "#fff8c5ff",
+        "modified.border": "#d4a72c66",
+        "pane.focused_border": "#d1d9e0ff",
+        "panel.background": "#f6f8faff",
+        "panel.focused_border": "#d1d9e0ff",
+        "predictive.background": "#818b981f",
+        "predictive.border": "#d1d9e0b3",
+        "renamed": "#0969daff",
+        "renamed.background": "#ddf4ffff",
+        "renamed.border": "#54aeff66",
+        "scrollbar.thumb.border": "#ffffff00",
+        "scrollbar.thumb.hover_background": "#f6f8faff",
+        "scrollbar.track.background": "#ffffff00",
+        "scrollbar.track.border": "#ffffff00",
+        "search.match_background": "#fff8c5ff",
+        "status_bar.background": "#f6f8faff",
+        "success": "#0969daff",
+        "success.background": "#ddf4ffff",
+        "success.border": "#54aeff66",
+        "surface.background": "#f6f8faff",
+        "tab.active_background": "#ffffffff",
+        "tab.inactive_background": "#f6f8faff",
+        "tab_bar.background": "#f6f8faff",
+        "terminal.ansi.black": "#1f2328ff",
+        "terminal.ansi.bright_black": "#393f46ff",
+        "terminal.ansi.dim_black": "#1f2328ff",
+        "terminal.ansi.blue": "#0969daff",
+        "terminal.ansi.bright_blue": "#218bffff",
+        "terminal.ansi.dim_blue": "#0969daff",
+        "terminal.ansi.cyan": "#1b7c83ff",
+        "terminal.ansi.bright_cyan": "#3192aaff",
+        "terminal.ansi.dim_cyan": "#1b7c83ff",
+        "terminal.ansi.green": "#0550aeff",
+        "terminal.ansi.bright_green": "#0969daff",
+        "terminal.ansi.dim_green": "#0550aeff",
+        "terminal.ansi.magenta": "#8250dfff",
+        "terminal.ansi.bright_magenta": "#a475f9ff",
+        "terminal.ansi.dim_magenta": "#8250dfff",
+        "terminal.ansi.red": "#cf222eff",
+        "terminal.ansi.bright_red": "#a40e26ff",
+        "terminal.ansi.dim_red": "#cf222eff",
+        "terminal.ansi.white": "#59636eff",
+        "terminal.ansi.bright_white": "#818b98ff",
+        "terminal.ansi.dim_white": "#59636eff",
+        "terminal.ansi.yellow": "#4d2d00ff",
+        "terminal.ansi.bright_yellow": "#633c01ff",
+        "terminal.ansi.dim_yellow": "#4d2d00ff",
+        "terminal.background": "#f6f8faff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#1f2328ff",
+        "terminal.foreground": "#59636eff",
+        "text": "#1f2328ff",
+        "text.accent": "#0969daff",
+        "text.disabled": "#818b98ff",
+        "text.muted": "#59636eff",
+        "title_bar.background": "#f6f8faff",
+        "toolbar.background": "#ffffffff",
+        "unreachable": "#818b98ff",
+        "unreachable.background": "#eff2f5ff",
+        "unreachable.border": "#818b981a",
+        "warning": "#9a6700ff",
+        "warning.background": "#f6f8faff",
+        "warning.border": "#d1d9e0b3",
+        "players": [
+          {
+            "background": "#d1f0ffff",
+            "border": "#d1f0ffff"
+          },
+          {
+            "background": "#ffe7d1ff",
+            "border": "#ffe7d1ff"
+          },
+          {
+            "background": "#ffe5f1ff",
+            "border": "#ffe5f1ff"
+          },
+          {
+            "background": "#caf7caff",
+            "border": "#caf7caff"
+          },
+          {
+            "background": "#f1e5ffff",
+            "border": "#f1e5ffff"
+          },
+          {
+            "background": "#ffec9eff",
+            "border": "#ffec9eff"
+          },
+          {
+            "background": "#c7f5efff",
+            "border": "#c7f5efff"
+          },
+          {
+            "background": "#ffe2e0ff",
+            "border": "#ffe2e0ff"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#59636eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#59636eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "fgColor/muted",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#0a3069ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "fgColor/placeholder",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#0a3069ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#116329ff",
+            "font_style": "bold",
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#0a3069ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#116329ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+      "appearance": "dark",
+      "name": "Github Dark Default",
+      "style": {
+        "background": "#0d1117ff",
+        "border": "#3d444dff",
+        "border.disabled": "#656c761a",
+        "border.focused": "#1f6febff",
+        "border.selected": "#1f6febff",
+        "border.transparent": "#00000000",
+        "border.variant": "#3d444db3",
+        "conflict": "#db6d28ff",
+        "conflict.background": "#db6d281a",
+        "conflict.border": "#db6d2866",
+        "created": "#3fb950ff",
+        "created.background": "#2ea04326",
+        "created.border": "#2ea04366",
+        "deleted": "#f85149ff",
+        "deleted.background": "#f851491a",
+        "deleted.border": "#f8514966",
+        "drop_target.background": "#388bfd1a",
+        "editor.active_line.background": "#151b23ff",
+        "editor.active_line_number": "#f0f6fcff",
+        "editor.active_wrap_guide": "#3d444db3",
+        "editor.background": "#0d1117ff",
+        "editor.document_highlight.read_background": "#388bfd1a",
+        "editor.document_highlight.write_background": "#1f6febff",
+        "editor.foreground": "#f0f6fcff",
+        "editor.gutter.background": "#0d1117ff",
+        "editor.highlighted_line.background": "#656c7633",
+        "editor.invisible": "#656c7699",
+        "editor.line_number": "#9198a1ff",
+        "editor.subheader.background": "#151b23ff",
+        "editor.wrap_guide": "#3d444db3",
+        "element.active": "#656c7633",
+        "element.background": "#656c7633",
+        "element.disabled": "#212830ff",
+        "element.hover": "#656c7633",
+        "element.selected": "#656c7633",
+        "elevated_surface.background": "#151b23ff",
+        "error": "#f85149ff",
+        "error.background": "#151b23ff",
+        "error.border": "#3d444db3",
+        "ghost_element.active": "#656c7633",
+        "ghost_element.background": "#00000000",
+        "ghost_element.disabled": "#212830ff",
+        "ghost_element.hover": "#0d1117ff",
+        "ghost_element.selected": "#656c7633",
+        "hint": "#9198a1ff",
+        "hint.background": "#151b23ff",
+        "hint.border": "#3d444db3",
+        "icon": "#f0f6fcff",
+        "icon.background": "#0d1117ff",
+        "icon.border": "#3d444dff",
+        "icon.accent": "#4493f8ff",
+        "icon.muted": "#9198a1ff",
+        "icon.disabled": "#656c7699",
+        "ignored": "#656c7699",
+        "ignored.background": "#212830ff",
+        "ignored.border": "#656c761a",
+        "info": "#d29922ff",
+        "info.background": "#151b23ff",
+        "info.border": "#3d444db3",
+        "link_text.hover": "#4493f8ff",
+        "modified": "#d29922ff",
+        "modified.background": "#bb800926",
+        "modified.border": "#bb800966",
+        "pane.focused_border": "#3d444dff",
+        "panel.background": "#010409ff",
+        "panel.focused_border": "#3d444dff",
+        "predictive.background": "#656c7633",
+        "predictive.border": "#3d444db3",
+        "renamed": "#3fb950ff",
+        "renamed.background": "#2ea04326",
+        "renamed.border": "#2ea04366",
+        "scrollbar.thumb.border": "#00000000",
+        "scrollbar.thumb.hover_background": "#151b23ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#00000000",
+        "search.match_background": "#bb800926",
+        "status_bar.background": "#010409ff",
+        "success": "#3fb950ff",
+        "success.background": "#2ea04326",
+        "success.border": "#2ea04366",
+        "surface.background": "#010409ff",
+        "tab.active_background": "#0d1117ff",
+        "tab.inactive_background": "#010409ff",
+        "tab_bar.background": "#010409ff",
+        "terminal.ansi.black": "#2f3742ff",
+        "terminal.ansi.bright_black": "#656c76ff",
+        "terminal.ansi.dim_black": "#2f3742ff",
+        "terminal.ansi.blue": "#58a6ffff",
+        "terminal.ansi.bright_blue": "#79c0ffff",
+        "terminal.ansi.dim_blue": "#58a6ffff",
+        "terminal.ansi.cyan": "#39c5cfff",
+        "terminal.ansi.bright_cyan": "#56d4ddff",
+        "terminal.ansi.dim_cyan": "#39c5cfff",
+        "terminal.ansi.green": "#3fb950ff",
+        "terminal.ansi.bright_green": "#56d364ff",
+        "terminal.ansi.dim_green": "#3fb950ff",
+        "terminal.ansi.magenta": "#be8fffff",
+        "terminal.ansi.bright_magenta": "#d2a8ffff",
+        "terminal.ansi.dim_magenta": "#be8fffff",
+        "terminal.ansi.red": "#ff7b72ff",
+        "terminal.ansi.bright_red": "#ffa198ff",
+        "terminal.ansi.dim_red": "#ff7b72ff",
+        "terminal.ansi.white": "#f0f6fcff",
+        "terminal.ansi.bright_white": "#ffffffff",
+        "terminal.ansi.dim_white": "#f0f6fcff",
+        "terminal.ansi.yellow": "#d29922ff",
+        "terminal.ansi.bright_yellow": "#e3b341ff",
+        "terminal.ansi.dim_yellow": "#d29922ff",
+        "terminal.background": "#010409ff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#f0f6fcff",
+        "terminal.foreground": "#9198a1ff",
+        "text": "#f0f6fcff",
+        "text.accent": "#4493f8ff",
+        "text.disabled": "#656c7699",
+        "text.muted": "#9198a1ff",
+        "title_bar.background": "#010409ff",
+        "toolbar.background": "#0d1117ff",
+        "unreachable": "#656c7699",
+        "unreachable.background": "#212830ff",
+        "unreachable.border": "#656c761a",
+        "warning": "#d29922ff",
+        "warning.background": "#151b23ff",
+        "warning.border": "#3d444db3",
+        "players": [
+          {
+            "background": "#001a47ff",
+            "border": "#001a47ff"
+          },
+          {
+            "background": "#311708ff",
+            "border": "#311708ff"
+          },
+          {
+            "background": "#2d1524ff",
+            "border": "#2d1524ff"
+          },
+          {
+            "background": "#122117ff",
+            "border": "#122117ff"
+          },
+          {
+            "background": "#211047ff",
+            "border": "#211047ff"
+          },
+          {
+            "background": "#2e1a00ff",
+            "border": "#2e1a00ff"
+          },
+          {
+            "background": "#041f25ff",
+            "border": "#041f25ff"
+          },
+          {
+            "background": "#3c0614ff",
+            "border": "#3c0614ff"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "fgColor/muted",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#a5d6ffff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "fgColor/placeholder",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#a5d6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#7ee787ff",
+            "font_style": "bold",
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#a5d6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#7ee787ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+      "appearance": "dark",
+      "name": "Github Dark Colorblind",
+      "style": {
+        "background": "#0d1117ff",
+        "border": "#3d444dff",
+        "border.disabled": "#656c761a",
+        "border.focused": "#1f6febff",
+        "border.selected": "#1f6febff",
+        "border.transparent": "#00000000",
+        "border.variant": "#3d444db3",
+        "conflict": "#db6d28ff",
+        "conflict.background": "#db6d281a",
+        "conflict.border": "#db6d2866",
+        "created": "#58a6ffff",
+        "created.background": "#388bfd26",
+        "created.border": "#388bfd66",
+        "deleted": "#db6d28ff",
+        "deleted.background": "#db6d281a",
+        "deleted.border": "#db6d2866",
+        "drop_target.background": "#388bfd1a",
+        "editor.active_line.background": "#151b23ff",
+        "editor.active_line_number": "#f0f6fcff",
+        "editor.active_wrap_guide": "#3d444db3",
+        "editor.background": "#0d1117ff",
+        "editor.document_highlight.read_background": "#388bfd1a",
+        "editor.document_highlight.write_background": "#1f6febff",
+        "editor.foreground": "#f0f6fcff",
+        "editor.gutter.background": "#0d1117ff",
+        "editor.highlighted_line.background": "#656c7633",
+        "editor.invisible": "#656c7699",
+        "editor.line_number": "#9198a1ff",
+        "editor.subheader.background": "#151b23ff",
+        "editor.wrap_guide": "#3d444db3",
+        "element.active": "#656c7633",
+        "element.background": "#656c7633",
+        "element.disabled": "#212830ff",
+        "element.hover": "#656c7633",
+        "element.selected": "#656c7633",
+        "elevated_surface.background": "#151b23ff",
+        "error": "#db6d28ff",
+        "error.background": "#151b23ff",
+        "error.border": "#3d444db3",
+        "ghost_element.active": "#656c7633",
+        "ghost_element.background": "#00000000",
+        "ghost_element.disabled": "#212830ff",
+        "ghost_element.hover": "#0d1117ff",
+        "ghost_element.selected": "#656c7633",
+        "hint": "#9198a1ff",
+        "hint.background": "#151b23ff",
+        "hint.border": "#3d444db3",
+        "icon": "#f0f6fcff",
+        "icon.background": "#0d1117ff",
+        "icon.border": "#3d444dff",
+        "icon.accent": "#4493f8ff",
+        "icon.muted": "#9198a1ff",
+        "icon.disabled": "#656c7699",
+        "ignored": "#656c7699",
+        "ignored.background": "#212830ff",
+        "ignored.border": "#656c761a",
+        "info": "#d29922ff",
+        "info.background": "#151b23ff",
+        "info.border": "#3d444db3",
+        "link_text.hover": "#4493f8ff",
+        "modified": "#d29922ff",
+        "modified.background": "#bb800926",
+        "modified.border": "#bb800966",
+        "pane.focused_border": "#3d444dff",
+        "panel.background": "#010409ff",
+        "panel.focused_border": "#3d444dff",
+        "predictive.background": "#656c7633",
+        "predictive.border": "#3d444db3",
+        "renamed": "#58a6ffff",
+        "renamed.background": "#388bfd26",
+        "renamed.border": "#388bfd66",
+        "scrollbar.thumb.border": "#00000000",
+        "scrollbar.thumb.hover_background": "#151b23ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#00000000",
+        "search.match_background": "#bb800926",
+        "status_bar.background": "#010409ff",
+        "success": "#58a6ffff",
+        "success.background": "#388bfd26",
+        "success.border": "#388bfd66",
+        "surface.background": "#010409ff",
+        "tab.active_background": "#0d1117ff",
+        "tab.inactive_background": "#010409ff",
+        "tab_bar.background": "#010409ff",
+        "terminal.ansi.black": "#2f3742ff",
+        "terminal.ansi.bright_black": "#656c76ff",
+        "terminal.ansi.dim_black": "#2f3742ff",
+        "terminal.ansi.blue": "#58a6ffff",
+        "terminal.ansi.bright_blue": "#79c0ffff",
+        "terminal.ansi.dim_blue": "#58a6ffff",
+        "terminal.ansi.cyan": "#39c5cfff",
+        "terminal.ansi.bright_cyan": "#56d4ddff",
+        "terminal.ansi.dim_cyan": "#39c5cfff",
+        "terminal.ansi.green": "#58a6ffff",
+        "terminal.ansi.bright_green": "#79c0ffff",
+        "terminal.ansi.dim_green": "#58a6ffff",
+        "terminal.ansi.magenta": "#be8fffff",
+        "terminal.ansi.bright_magenta": "#d2a8ffff",
+        "terminal.ansi.dim_magenta": "#be8fffff",
+        "terminal.ansi.red": "#f0883eff",
+        "terminal.ansi.bright_red": "#ffa657ff",
+        "terminal.ansi.dim_red": "#f0883eff",
+        "terminal.ansi.white": "#f0f6fcff",
+        "terminal.ansi.bright_white": "#ffffffff",
+        "terminal.ansi.dim_white": "#f0f6fcff",
+        "terminal.ansi.yellow": "#d29922ff",
+        "terminal.ansi.bright_yellow": "#e3b341ff",
+        "terminal.ansi.dim_yellow": "#d29922ff",
+        "terminal.background": "#010409ff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#f0f6fcff",
+        "terminal.foreground": "#9198a1ff",
+        "text": "#f0f6fcff",
+        "text.accent": "#4493f8ff",
+        "text.disabled": "#656c7699",
+        "text.muted": "#9198a1ff",
+        "title_bar.background": "#010409ff",
+        "toolbar.background": "#0d1117ff",
+        "unreachable": "#656c7699",
+        "unreachable.background": "#212830ff",
+        "unreachable.border": "#656c761a",
+        "warning": "#d29922ff",
+        "warning.background": "#151b23ff",
+        "warning.border": "#3d444db3",
+        "players": [
+          {
+            "background": "#001a47ff",
+            "border": "#001a47ff"
+          },
+          {
+            "background": "#311708ff",
+            "border": "#311708ff"
+          },
+          {
+            "background": "#2d1524ff",
+            "border": "#2d1524ff"
+          },
+          {
+            "background": "#122117ff",
+            "border": "#122117ff"
+          },
+          {
+            "background": "#211047ff",
+            "border": "#211047ff"
+          },
+          {
+            "background": "#2e1a00ff",
+            "border": "#2e1a00ff"
+          },
+          {
+            "background": "#041f25ff",
+            "border": "#041f25ff"
+          },
+          {
+            "background": "#3c0614ff",
+            "border": "#3c0614ff"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "fgColor/muted",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#a5d6ffff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "fgColor/placeholder",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#a5d6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#7ee787ff",
+            "font_style": "bold",
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#a5d6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#7ee787ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+      "appearance": "dark",
+      "name": "Github Dark High Contrast",
+      "style": {
+        "background": "#010409ff",
+        "border": "#b7bdc8ff",
+        "border.disabled": "#9198a11f",
+        "border.focused": "#409effff",
+        "border.selected": "#409effff",
+        "border.transparent": "#00000000",
+        "border.variant": "#b7bdc8ff",
+        "conflict": "#fe9a2dff",
+        "conflict.background": "#f48b251a",
+        "conflict.border": "#f48b25ff",
+        "created": "#2bd853ff",
+        "created.background": "#0ac74026",
+        "created.border": "#0ac740ff",
+        "deleted": "#ff9492ff",
+        "deleted.background": "#ff80801a",
+        "deleted.border": "#ff8080ff",
+        "drop_target.background": "#5cacff1a",
+        "editor.active_line.background": "#151b23ff",
+        "editor.active_line_number": "#ffffffff",
+        "editor.active_wrap_guide": "#b7bdc8ff",
+        "editor.background": "#010409ff",
+        "editor.document_highlight.read_background": "#5cacff1a",
+        "editor.document_highlight.write_background": "#194fb1ff",
+        "editor.foreground": "#ffffffff",
+        "editor.gutter.background": "#010409ff",
+        "editor.highlighted_line.background": "#212830ff",
+        "editor.invisible": "#9198a199",
+        "editor.line_number": "#b7bdc8ff",
+        "editor.subheader.background": "#151b23ff",
+        "editor.wrap_guide": "#b7bdc8ff",
+        "element.active": "#212830ff",
+        "element.background": "#212830ff",
+        "element.disabled": "#262c36ff",
+        "element.hover": "#212830ff",
+        "element.selected": "#212830ff",
+        "elevated_surface.background": "#151b23ff",
+        "error": "#ff9492ff",
+        "error.background": "#151b23ff",
+        "error.border": "#b7bdc8ff",
+        "ghost_element.active": "#212830ff",
+        "ghost_element.background": "#00000000",
+        "ghost_element.disabled": "#262c36ff",
+        "ghost_element.hover": "#010409ff",
+        "ghost_element.selected": "#212830ff",
+        "hint": "#b7bdc8ff",
+        "hint.background": "#151b23ff",
+        "hint.border": "#b7bdc8ff",
+        "icon": "#ffffffff",
+        "icon.background": "#010409ff",
+        "icon.border": "#b7bdc8ff",
+        "icon.accent": "#74b9ffff",
+        "icon.muted": "#b7bdc8ff",
+        "icon.disabled": "#9198a199",
+        "ignored": "#9198a199",
+        "ignored.background": "#262c36ff",
+        "ignored.border": "#9198a11f",
+        "info": "#f0b72fff",
+        "info.background": "#151b23ff",
+        "info.border": "#b7bdc8ff",
+        "link_text.hover": "#74b9ffff",
+        "modified": "#f0b72fff",
+        "modified.background": "#edaa2726",
+        "modified.border": "#edaa27ff",
+        "pane.focused_border": "#b7bdc8ff",
+        "panel.background": "#010409ff",
+        "panel.focused_border": "#b7bdc8ff",
+        "predictive.background": "#212830ff",
+        "predictive.border": "#b7bdc8ff",
+        "renamed": "#2bd853ff",
+        "renamed.background": "#0ac74026",
+        "renamed.border": "#0ac740ff",
+        "scrollbar.thumb.border": "#00000000",
+        "scrollbar.thumb.hover_background": "#151b23ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#00000000",
+        "search.match_background": "#edaa2726",
+        "status_bar.background": "#010409ff",
+        "success": "#2bd853ff",
+        "success.background": "#0ac74026",
+        "success.border": "#0ac740ff",
+        "surface.background": "#010409ff",
+        "tab.active_background": "#010409ff",
+        "tab.inactive_background": "#010409ff",
+        "tab_bar.background": "#010409ff",
+        "terminal.ansi.black": "#2f3742ff",
+        "terminal.ansi.bright_black": "#656c76ff",
+        "terminal.ansi.dim_black": "#2f3742ff",
+        "terminal.ansi.blue": "#71b7ffff",
+        "terminal.ansi.bright_blue": "#91cbffff",
+        "terminal.ansi.dim_blue": "#71b7ffff",
+        "terminal.ansi.cyan": "#39c5cfff",
+        "terminal.ansi.bright_cyan": "#56d4ddff",
+        "terminal.ansi.dim_cyan": "#39c5cfff",
+        "terminal.ansi.green": "#28d751ff",
+        "terminal.ansi.bright_green": "#4ae168ff",
+        "terminal.ansi.dim_green": "#28d751ff",
+        "terminal.ansi.magenta": "#cb9effff",
+        "terminal.ansi.bright_magenta": "#dbb7ffff",
+        "terminal.ansi.dim_magenta": "#cb9effff",
+        "terminal.ansi.red": "#ff9492ff",
+        "terminal.ansi.bright_red": "#ffb1afff",
+        "terminal.ansi.dim_red": "#ff9492ff",
+        "terminal.ansi.white": "#f0f6fcff",
+        "terminal.ansi.bright_white": "#ffffffff",
+        "terminal.ansi.dim_white": "#f0f6fcff",
+        "terminal.ansi.yellow": "#f0b72fff",
+        "terminal.ansi.bright_yellow": "#f7c843ff",
+        "terminal.ansi.dim_yellow": "#f0b72fff",
+        "terminal.background": "#010409ff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#ffffffff",
+        "terminal.foreground": "#b7bdc8ff",
+        "text": "#ffffffff",
+        "text.accent": "#74b9ffff",
+        "text.disabled": "#9198a199",
+        "text.muted": "#b7bdc8ff",
+        "title_bar.background": "#010409ff",
+        "toolbar.background": "#010409ff",
+        "unreachable": "#9198a199",
+        "unreachable.background": "#262c36ff",
+        "unreachable.border": "#9198a11f",
+        "warning": "#f0b72fff",
+        "warning.background": "#151b23ff",
+        "warning.border": "#b7bdc8ff",
+        "players": [
+          {
+            "background": "#001a47ff",
+            "border": "#001a47ff"
+          },
+          {
+            "background": "#311708ff",
+            "border": "#311708ff"
+          },
+          {
+            "background": "#2d1524ff",
+            "border": "#2d1524ff"
+          },
+          {
+            "background": "#122117ff",
+            "border": "#122117ff"
+          },
+          {
+            "background": "#211047ff",
+            "border": "#211047ff"
+          },
+          {
+            "background": "#2e1a00ff",
+            "border": "#2e1a00ff"
+          },
+          {
+            "background": "#041f25ff",
+            "border": "#041f25ff"
+          },
+          {
+            "background": "#3c0614ff",
+            "border": "#3c0614ff"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#ffb757ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#ff9492ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#ffb757ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#dbb7ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#dbb7ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#dbb7ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "fgColor/muted",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#ff9492ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#addcffff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "fgColor/placeholder",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#ff9492ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#ffb757ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#ff9492ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#addcffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#72f088ff",
+            "font_style": "bold",
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#addcffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#72f088ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#ffb757ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#ffb757ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#ff9492ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#ffb757ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+      "appearance": "dark",
+      "name": "Github Dark Tritanopia",
+      "style": {
+        "background": "#0d1117ff",
+        "border": "#3d444dff",
+        "border.disabled": "#656c761a",
+        "border.focused": "#1f6febff",
+        "border.selected": "#1f6febff",
+        "border.transparent": "#00000000",
+        "border.variant": "#3d444db3",
+        "conflict": "#f85149ff",
+        "conflict.background": "#f851491a",
+        "conflict.border": "#f8514966",
+        "created": "#58a6ffff",
+        "created.background": "#388bfd26",
+        "created.border": "#388bfd66",
+        "deleted": "#f85149ff",
+        "deleted.background": "#f851491a",
+        "deleted.border": "#f8514966",
+        "drop_target.background": "#388bfd1a",
+        "editor.active_line.background": "#151b23ff",
+        "editor.active_line_number": "#f0f6fcff",
+        "editor.active_wrap_guide": "#3d444db3",
+        "editor.background": "#0d1117ff",
+        "editor.document_highlight.read_background": "#388bfd1a",
+        "editor.document_highlight.write_background": "#1f6febff",
+        "editor.foreground": "#f0f6fcff",
+        "editor.gutter.background": "#0d1117ff",
+        "editor.highlighted_line.background": "#656c7633",
+        "editor.invisible": "#656c7699",
+        "editor.line_number": "#9198a1ff",
+        "editor.subheader.background": "#151b23ff",
+        "editor.wrap_guide": "#3d444db3",
+        "element.active": "#656c7633",
+        "element.background": "#656c7633",
+        "element.disabled": "#212830ff",
+        "element.hover": "#656c7633",
+        "element.selected": "#656c7633",
+        "elevated_surface.background": "#151b23ff",
+        "error": "#f85149ff",
+        "error.background": "#151b23ff",
+        "error.border": "#3d444db3",
+        "ghost_element.active": "#656c7633",
+        "ghost_element.background": "#00000000",
+        "ghost_element.disabled": "#212830ff",
+        "ghost_element.hover": "#0d1117ff",
+        "ghost_element.selected": "#656c7633",
+        "hint": "#9198a1ff",
+        "hint.background": "#151b23ff",
+        "hint.border": "#3d444db3",
+        "icon": "#f0f6fcff",
+        "icon.background": "#0d1117ff",
+        "icon.border": "#3d444dff",
+        "icon.accent": "#4493f8ff",
+        "icon.muted": "#9198a1ff",
+        "icon.disabled": "#656c7699",
+        "ignored": "#656c7699",
+        "ignored.background": "#212830ff",
+        "ignored.border": "#656c761a",
+        "info": "#d29922ff",
+        "info.background": "#151b23ff",
+        "info.border": "#3d444db3",
+        "link_text.hover": "#4493f8ff",
+        "modified": "#d29922ff",
+        "modified.background": "#bb800926",
+        "modified.border": "#bb800966",
+        "pane.focused_border": "#3d444dff",
+        "panel.background": "#010409ff",
+        "panel.focused_border": "#3d444dff",
+        "predictive.background": "#656c7633",
+        "predictive.border": "#3d444db3",
+        "renamed": "#58a6ffff",
+        "renamed.background": "#388bfd26",
+        "renamed.border": "#388bfd66",
+        "scrollbar.thumb.border": "#00000000",
+        "scrollbar.thumb.hover_background": "#151b23ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#00000000",
+        "search.match_background": "#bb800926",
+        "status_bar.background": "#010409ff",
+        "success": "#58a6ffff",
+        "success.background": "#388bfd26",
+        "success.border": "#388bfd66",
+        "surface.background": "#010409ff",
+        "tab.active_background": "#0d1117ff",
+        "tab.inactive_background": "#010409ff",
+        "tab_bar.background": "#010409ff",
+        "terminal.ansi.black": "#2f3742ff",
+        "terminal.ansi.bright_black": "#656c76ff",
+        "terminal.ansi.dim_black": "#2f3742ff",
+        "terminal.ansi.blue": "#58a6ffff",
+        "terminal.ansi.bright_blue": "#79c0ffff",
+        "terminal.ansi.dim_blue": "#58a6ffff",
+        "terminal.ansi.cyan": "#39c5cfff",
+        "terminal.ansi.bright_cyan": "#56d4ddff",
+        "terminal.ansi.dim_cyan": "#39c5cfff",
+        "terminal.ansi.green": "#58a6ffff",
+        "terminal.ansi.bright_green": "#79c0ffff",
+        "terminal.ansi.dim_green": "#58a6ffff",
+        "terminal.ansi.magenta": "#be8fffff",
+        "terminal.ansi.bright_magenta": "#d2a8ffff",
+        "terminal.ansi.dim_magenta": "#be8fffff",
+        "terminal.ansi.red": "#ff7b72ff",
+        "terminal.ansi.bright_red": "#ffa198ff",
+        "terminal.ansi.dim_red": "#ff7b72ff",
+        "terminal.ansi.white": "#f0f6fcff",
+        "terminal.ansi.bright_white": "#ffffffff",
+        "terminal.ansi.dim_white": "#f0f6fcff",
+        "terminal.ansi.yellow": "#d29922ff",
+        "terminal.ansi.bright_yellow": "#e3b341ff",
+        "terminal.ansi.dim_yellow": "#d29922ff",
+        "terminal.background": "#010409ff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#f0f6fcff",
+        "terminal.foreground": "#9198a1ff",
+        "text": "#f0f6fcff",
+        "text.accent": "#4493f8ff",
+        "text.disabled": "#656c7699",
+        "text.muted": "#9198a1ff",
+        "title_bar.background": "#010409ff",
+        "toolbar.background": "#0d1117ff",
+        "unreachable": "#656c7699",
+        "unreachable.background": "#212830ff",
+        "unreachable.border": "#656c761a",
+        "warning": "#d29922ff",
+        "warning.background": "#151b23ff",
+        "warning.border": "#3d444db3",
+        "players": [
+          {
+            "background": "#001a47ff",
+            "border": "#001a47ff"
+          },
+          {
+            "background": "#311708ff",
+            "border": "#311708ff"
+          },
+          {
+            "background": "#2d1524ff",
+            "border": "#2d1524ff"
+          },
+          {
+            "background": "#122117ff",
+            "border": "#122117ff"
+          },
+          {
+            "background": "#211047ff",
+            "border": "#211047ff"
+          },
+          {
+            "background": "#2e1a00ff",
+            "border": "#2e1a00ff"
+          },
+          {
+            "background": "#041f25ff",
+            "border": "#041f25ff"
+          },
+          {
+            "background": "#3c0614ff",
+            "border": "#3c0614ff"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "fgColor/muted",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#a5d6ffff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "fgColor/placeholder",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#a5d6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#7ee787ff",
+            "font_style": "bold",
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#a5d6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#7ee787ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+      "appearance": "dark",
+      "name": "Github Dark Dimmed",
+      "style": {
+        "background": "#212830ff",
+        "border": "#3d444dff",
+        "border.disabled": "#656c761a",
+        "border.focused": "#316dcaff",
+        "border.selected": "#316dcaff",
+        "border.transparent": "#00000000",
+        "border.variant": "#3d444db3",
+        "conflict": "#cc6b2cff",
+        "conflict.background": "#cc6b2c1a",
+        "conflict.border": "#cc6b2c66",
+        "created": "#57ab5aff",
+        "created.background": "#46954a26",
+        "created.border": "#46954a66",
+        "deleted": "#e5534bff",
+        "deleted.background": "#e5534b1a",
+        "deleted.border": "#e5534b66",
+        "drop_target.background": "#4184e41a",
+        "editor.active_line.background": "#262c36ff",
+        "editor.active_line_number": "#d1d7e0ff",
+        "editor.active_wrap_guide": "#3d444db3",
+        "editor.background": "#212830ff",
+        "editor.document_highlight.read_background": "#4184e41a",
+        "editor.document_highlight.write_background": "#316dcaff",
+        "editor.foreground": "#d1d7e0ff",
+        "editor.gutter.background": "#212830ff",
+        "editor.highlighted_line.background": "#656c7633",
+        "editor.invisible": "#656c76ff",
+        "editor.line_number": "#9198a1ff",
+        "editor.subheader.background": "#262c36ff",
+        "editor.wrap_guide": "#3d444db3",
+        "element.active": "#656c7633",
+        "element.background": "#656c7633",
+        "element.disabled": "#2a313cff",
+        "element.hover": "#656c7633",
+        "element.selected": "#656c7633",
+        "elevated_surface.background": "#262c36ff",
+        "error": "#e5534bff",
+        "error.background": "#262c36ff",
+        "error.border": "#3d444db3",
+        "ghost_element.active": "#656c7633",
+        "ghost_element.background": "#00000000",
+        "ghost_element.disabled": "#2a313cff",
+        "ghost_element.hover": "#212830ff",
+        "ghost_element.selected": "#656c7633",
+        "hint": "#9198a1ff",
+        "hint.background": "#262c36ff",
+        "hint.border": "#3d444db3",
+        "icon": "#d1d7e0ff",
+        "icon.background": "#212830ff",
+        "icon.border": "#3d444dff",
+        "icon.accent": "#478be6ff",
+        "icon.muted": "#9198a1ff",
+        "icon.disabled": "#656c76ff",
+        "ignored": "#656c76ff",
+        "ignored.background": "#2a313cff",
+        "ignored.border": "#656c761a",
+        "info": "#c69026ff",
+        "info.background": "#262c36ff",
+        "info.border": "#3d444db3",
+        "link_text.hover": "#478be6ff",
+        "modified": "#c69026ff",
+        "modified.background": "#ae7c1426",
+        "modified.border": "#ae7c1466",
+        "pane.focused_border": "#3d444dff",
+        "panel.background": "#151b23ff",
+        "panel.focused_border": "#3d444dff",
+        "predictive.background": "#656c7633",
+        "predictive.border": "#3d444db3",
+        "renamed": "#57ab5aff",
+        "renamed.background": "#46954a26",
+        "renamed.border": "#46954a66",
+        "scrollbar.thumb.border": "#00000000",
+        "scrollbar.thumb.hover_background": "#262c36ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#00000000",
+        "search.match_background": "#ae7c1426",
+        "status_bar.background": "#151b23ff",
+        "success": "#57ab5aff",
+        "success.background": "#46954a26",
+        "success.border": "#46954a66",
+        "surface.background": "#151b23ff",
+        "tab.active_background": "#212830ff",
+        "tab.inactive_background": "#151b23ff",
+        "tab_bar.background": "#151b23ff",
+        "terminal.ansi.black": "#2f3742ff",
+        "terminal.ansi.bright_black": "#656c76ff",
+        "terminal.ansi.dim_black": "#2f3742ff",
+        "terminal.ansi.blue": "#539bf5ff",
+        "terminal.ansi.bright_blue": "#6cb6ffff",
+        "terminal.ansi.dim_blue": "#539bf5ff",
+        "terminal.ansi.cyan": "#39c5cfff",
+        "terminal.ansi.bright_cyan": "#56d4ddff",
+        "terminal.ansi.dim_cyan": "#39c5cfff",
+        "terminal.ansi.green": "#57ab5aff",
+        "terminal.ansi.bright_green": "#6bc46dff",
+        "terminal.ansi.dim_green": "#57ab5aff",
+        "terminal.ansi.magenta": "#b083f0ff",
+        "terminal.ansi.bright_magenta": "#dcbdfbff",
+        "terminal.ansi.dim_magenta": "#b083f0ff",
+        "terminal.ansi.red": "#f47067ff",
+        "terminal.ansi.bright_red": "#ff938aff",
+        "terminal.ansi.dim_red": "#f47067ff",
+        "terminal.ansi.white": "#f0f6fcff",
+        "terminal.ansi.bright_white": "#cdd9e5ff",
+        "terminal.ansi.dim_white": "#f0f6fcff",
+        "terminal.ansi.yellow": "#c69026ff",
+        "terminal.ansi.bright_yellow": "#daaa3fff",
+        "terminal.ansi.dim_yellow": "#c69026ff",
+        "terminal.background": "#151b23ff",
+        "terminal.bright_foreground": "#f0f6fcff",
+        "terminal.dim_foreground": "#d1d7e0ff",
+        "terminal.foreground": "#9198a1ff",
+        "text": "#d1d7e0ff",
+        "text.accent": "#478be6ff",
+        "text.disabled": "#656c76ff",
+        "text.muted": "#9198a1ff",
+        "title_bar.background": "#151b23ff",
+        "toolbar.background": "#212830ff",
+        "unreachable": "#656c76ff",
+        "unreachable.background": "#2a313cff",
+        "unreachable.border": "#656c761a",
+        "warning": "#c69026ff",
+        "warning.background": "#262c36ff",
+        "warning.border": "#3d444db3",
+        "players": [
+          {
+            "background": "#001a47ff",
+            "border": "#001a47ff"
+          },
+          {
+            "background": "#311708ff",
+            "border": "#311708ff"
+          },
+          {
+            "background": "#2d1524ff",
+            "border": "#2d1524ff"
+          },
+          {
+            "background": "#122117ff",
+            "border": "#122117ff"
+          },
+          {
+            "background": "#211047ff",
+            "border": "#211047ff"
+          },
+          {
+            "background": "#2e1a00ff",
+            "border": "#2e1a00ff"
+          },
+          {
+            "background": "#041f25ff",
+            "border": "#041f25ff"
+          },
+          {
+            "background": "#3c0614ff",
+            "border": "#3c0614ff"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#f69d50ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#f47067ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#f69d50ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#dcbdfbff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#dcbdfbff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#dcbdfbff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "fgColor/muted",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#f47067ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#96d0ffff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "fgColor/placeholder",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#f47067ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "fgColor/default",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#f69d50ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#f47067ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#96d0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#8ddb8cff",
+            "font_style": "bold",
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#96d0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#8ddb8cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#f69d50ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#f69d50ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#f47067ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#f69d50ff",
             "font_style": null,
             "font_weight": null
           }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "types": [
+      "node"
+    ],
+    "target": "ESNext",
+    "module": "ESNext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "alwaysStrict": true,
+    "allowUnreachableCode": false,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "declaration": false
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules/**/*"
+  ]
+}


### PR DESCRIPTION
Hi!

This updates the themes so that instead of being manually written out, they are generated from the primer design system. This is similar to how the [github vscode theme is generated](https://github.com/primer/github-vscode-theme/tree/38b50d41bdc6b190b7351e220956af043221d763), with the main difference being that this uses a newer version of the primer library.

This now generates a handful of themes, one for each color scheme in the primer design system:

- Github Light Default
- Github Light Colorblind
- Github Light High Contrast
- Github Light Tritanopia
- Github Dark Default
- Github Dark High Contrast
- Github Dark Tritanopia
- Github Dark Dimmed 

This is a pretty significant departure from the existing repo, however it brings the themes more inline with the existing github ecosystem, and will be easier to keep up-to-date in the future.

Additionally, this PR migrates the `extension.json` file to the newer `extension.toml` format.

_Also threw my name in as a package co-author as this is a significant refactor 😅_


Lmk your thoughts!